### PR TITLE
(GH-16) Do not warn on "\s" string literal

### DIFF
--- a/lib/puppet-lint/plugins/check_strings/double_quoted_strings.rb
+++ b/lib/puppet-lint/plugins/check_strings/double_quoted_strings.rb
@@ -4,7 +4,7 @@
 #
 # https://puppet.com/docs/puppet/latest/style_guide.html#quoting
 PuppetLint.new_check(:double_quoted_strings) do
-  ESCAPE_CHAR_RE = %r{(\\\$|\\"|\\'|'|\r|\t|\\t|\n|\\n|\\\\)}
+  ESCAPE_CHAR_RE = %r{(\\\$|\\"|\\'|'|\r|\t|\\t|\\s|\n|\\n|\\\\)}
 
   def check
     tokens.select { |token|

--- a/spec/puppet-lint/plugins/check_strings/double_quoted_strings_spec.rb
+++ b/spec/puppet-lint/plugins/check_strings/double_quoted_strings_spec.rb
@@ -103,6 +103,7 @@ describe 'double_quoted_strings' do
           $string5 = "this string contains \\'escaped \\' single quotes"
           $string6 = "this string contains \r carriage return"
           $string7 = "this string contains \\\\ an escaped backslash"
+          $string8 = "this string contains \\s"
         END
       end
 


### PR DESCRIPTION
Prior to this commit, if the `\s` escape sequence was used, this
would cause a F+ from the `double_quoted_strings` check.

This commit updates the `double_quoted_string` check to permit the
`\s` string literal.

Resolves: #16 