### PR TITLE
support arbitary mountpoints for puppet url's

### DIFF
--- a/lib/puppet-lint/plugins/check_strings/puppet_url_without_modules.rb
+++ b/lib/puppet-lint/plugins/check_strings/puppet_url_without_modules.rb
@@ -8,7 +8,7 @@ PuppetLint.new_check(:puppet_url) do
     tokens.select { |token|
       (token.type == :SSTRING || token.type == :STRING || token.type == :DQPRE) && token.value.start_with?('puppet://')
     }.reject { |token|
-      (token.value[%r{puppet://.*?/modules/(?=\w+/\w+).*}] || token.value[%r{puppet://.*?/(?!modules)\w+/.*}]) unless token.value[%r{puppet://.*?/(.+)}, 1].nil?
+      (token.value[%r{puppet://.*?/(?!modules)\w+/.*}]) unless token.value[%r{puppet://.*?/(.+)}, 1].nil?
     }.each do |token|
       notify(
         :warning,

--- a/lib/puppet-lint/plugins/check_strings/puppet_url_without_modules.rb
+++ b/lib/puppet-lint/plugins/check_strings/puppet_url_without_modules.rb
@@ -3,16 +3,16 @@
 # instance found.
 #
 # No style guide reference
-PuppetLint.new_check(:puppet_url_without_modules) do
+PuppetLint.new_check(:puppet_url) do
   def check
     tokens.select { |token|
       (token.type == :SSTRING || token.type == :STRING || token.type == :DQPRE) && token.value.start_with?('puppet://')
     }.reject { |token|
-      token.value[%r{puppet://.*?/(.+)}, 1].start_with?('modules/') unless token.value[%r{puppet://.*?/(.+)}, 1].nil?
+      (token.value[%r{puppet://.*?/modules/(?=\w+/\w+).*}] || token.value[%r{puppet://.*?/(?!modules)\w+/.*}]) unless token.value[%r{puppet://.*?/(.+)}, 1].nil?
     }.each do |token|
       notify(
         :warning,
-        :message => 'puppet:// URL without modules/ found',
+        :message => 'invalid puppet:// URL found',
         :line    => token.line,
         :column  => token.column,
         :token   => token

--- a/spec/puppet-lint/plugins/check_strings/puppet_url_without_modules_spec.rb
+++ b/spec/puppet-lint/plugins/check_strings/puppet_url_without_modules_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe 'puppet_url_without_modules' do
-  let(:msg) { 'puppet:// URL without modules/ found' }
+describe 'puppet_url' do
+  let(:msg) { 'invalid puppet:// URL found' }
 
-  context 'puppet:// url with modules' do
-    let(:code) { "'puppet:///modules/foo'" }
+  context 'puppet:// url with mountpoint' do
+    let(:code) { "'puppet:///mountpoint/foo'" }
 
     it 'should not detect any problems' do
       expect(problems).to have(0).problems
@@ -12,8 +12,20 @@ describe 'puppet_url_without_modules' do
   end
 
   context 'with fix disabled' do
-    context 'puppet:// url without modules' do
+    context 'puppet:// url without mountpoint' do
       let(:code) { "'puppet:///foo'" }
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create a warning' do
+        expect(problems).to contain_warning(msg).on_line(1).in_column(1)
+      end
+    end
+
+    context 'puppet:// url without module name' do
+      let(:code) { "'puppet://modules/foo'" }
 
       it 'should only detect a single problem' do
         expect(problems).to have(1).problem
@@ -34,7 +46,7 @@ describe 'puppet_url_without_modules' do
       PuppetLint.configuration.fix = false
     end
 
-    context 'puppet:// url without modules' do
+    context 'puppet:// url without mountpoint' do
       let(:code) { "'puppet:///foo'" }
 
       it 'should only detect a single problem' do
@@ -45,8 +57,24 @@ describe 'puppet_url_without_modules' do
         expect(problems).to contain_fixed(msg).on_line(1).in_column(1)
       end
 
-      it 'should insert modules into the path' do
-        expect(manifest).to eq("'puppet:///modules/foo'")
+      it 'should insert mountpoint into the path' do
+        expect(manifest).to eq("'puppet:///mountpoint/foo'")
+      end
+    end
+
+    context 'puppet:// url without module name' do
+      let(:code) { "'puppet://modules/foo'" }
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should fix the manifest' do
+        expect(problems).to contain_fixed(msg).on_line(1).in_column(1)
+      end
+
+      it 'should insert mountpoint into the path' do
+        expect(manifest).to eq("'puppet:///modules/foo/bar'")
       end
     end
   end


### PR DESCRIPTION
I tested the regex's against these values

- puppet:///modules/modulename/file 
- puppet:///othermount/file
- puppet:///othermount/path/file
- puppet:///modules/filename 
- puppet:///filename

I'm not familiar with RSPEC, so I tried to follow the structure of what was there