### PR TITLE
Don't print GitHub annotations in JSON mode

### DIFF
--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -177,9 +177,8 @@ class PuppetLint
       else
         format_message(message)
         print_context(message) if configuration.with_context
+        print_github_annotation(message) if configuration.github_actions
       end
-
-      print_github_annotation(message) if configuration.github_actions
     end
     puts JSON.pretty_generate(json) if configuration.json
 


### PR DESCRIPTION
The output does not mix well. This does mean the PDK can't use these annotations, but at least it doesn't break it either.