### PR TITLE
Extend tested-modules in CI

### DIFF
--- a/lib/puppet-lint/tasks/release_test.rb
+++ b/lib/puppet-lint/tasks/release_test.rb
@@ -86,9 +86,12 @@ task :release_test do
     'puppetlabs/puppetlabs-chocolatey',
     'voxpupuli/puppet-archive',
     'voxpupuli/puppet-collectd',
+    'voxpupuli/puppet-prometheus',
+    'voxpupuli/puppet-borg',
+    'voxpupuli/puppet-nginx',
+    'voxpupuli/puppet-jenkins',
     'garethr/garethr-docker',
     'sensu/sensu-puppet',
-    'jenkinsci/puppet-jenkins',
   ]
 
   FileUtils.mkdir_p('tmp')


### PR DESCRIPTION
This PR adds a few modules that are tested during a puppet-lint CI run.
Those are modules from the community with a lot of Puppet Code/activity.