### PR TITLE
feat: Added support for advanced doc comment checking based on a number of rules in a rules file

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,22 @@ For a complete list of checks, and how to resolve errors on each check, see the 
 * When using top-scope variables, including facts, Puppet modules should explicitly specify the empty namespace.
 * Chaining operators should appear on the same line as the right hand operand.
 
+## Checking class/type documentation
+
+The check "advanced_doc_comments" supports checking the doc comment of a class or defined type based on rules
+defined in a rule file.
+
+The rule file is a JSON file holding an object representing the rules. Every rule can have the following
+parameters:
+
+* **check**: A regular expression that should match the whole doc comment. If it does not, the check fails
+* **condition**: A regular expression that is matched against the class/type source code. If it doesn't match
+  the rule is skipped.
+* **comment-condition**: A regular expression that is matched against the whole doc comment. If it doesn't
+  match the rule is skipped.
+
+See [this file](spec/puppet-lint/plugins/check_documentation/advanced_doc_comments_rules.json) for an example.
+
 ## Reporting bugs or incorrect results
 
 If you find a bug in Puppet Lint or its results, please create an issue in the

--- a/lib/puppet-lint/checkplugin.rb
+++ b/lib/puppet-lint/checkplugin.rb
@@ -156,7 +156,7 @@ class PuppetLint::CheckPlugin
 
   # Public: Report a problem with the manifest being checked.
   #
-  # kind    - The Symbol problem type (:warning or :error).
+  # kind    - The Symbol problem type (:warning or :error<).
   # problem - A Hash containing the attributes of the problem
   #   :message - The String message describing the problem.
   #   :line    - The Integer line number of the location of the problem.
@@ -179,5 +179,26 @@ class PuppetLint::CheckPlugin
     end
 
     @problems << problem
+  end
+
+  # Find the comment token above the given start token. Return nothing if not found
+  def find_comment_token(start_token)
+    prev_token = start_token.prev_token
+    found_comment = false
+    comment_token = nil
+    scanning_newlines = true
+    starting_newlines = 0
+    while !prev_token.nil? && (WHITESPACE_TOKENS + COMMENT_TOKENS).include?(prev_token.type)
+      scanning_newlines = false if COMMENT_TOKENS.include?(prev_token.type)
+      starting_newlines += 1 if prev_token.type == :NEWLINE
+      return if scanning_newlines && starting_newlines > 1
+      found_comment = true if !found_comment && COMMENT_TOKENS.include?(prev_token.type)
+      comment_token = prev_token if found_comment && COMMENT_TOKENS.include?(prev_token.type)
+      break if found_comment && !(WHITESPACE_TOKENS + COMMENT_TOKENS).include?(prev_token.type)
+      prev_token = prev_token.prev_token
+    end
+
+    return if comment_token.nil?
+    comment_token
   end
 end

--- a/lib/puppet-lint/checkplugin.rb
+++ b/lib/puppet-lint/checkplugin.rb
@@ -156,7 +156,7 @@ class PuppetLint::CheckPlugin
 
   # Public: Report a problem with the manifest being checked.
   #
-  # kind    - The Symbol problem type (:warning or :error<).
+  # kind    - The Symbol problem type (:warning or :error).
   # problem - A Hash containing the attributes of the problem
   #   :message - The String message describing the problem.
   #   :line    - The Integer line number of the location of the problem.

--- a/lib/puppet-lint/configuration.rb
+++ b/lib/puppet-lint/configuration.rb
@@ -35,6 +35,16 @@ class PuppetLint
       define_method("enable_#{check}") do
         settings["#{check}_disabled"] = false
       end
+
+      # Public: Determine if the check supports a configuration parameter
+      define_method("#{check}_supports_config?") do
+        return settings["#{check}_supports_config"] == true
+      end
+
+      # Public: Make the check support a configuration parameter
+      define_method("#{check}_supports_config") do
+        settings["#{check}_supports_config"] = true
+      end
     end
 
     # Public: Catch situations where options are being set for the first time

--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -125,10 +125,19 @@ class PuppetLint::OptParser
           PuppetLint.configuration.send("disable_#{check}")
         end
 
-        next if PuppetLint.configuration.send("#{check}_enabled?")
+        unless PuppetLint.configuration.send("#{check}_enabled?")
+          opts.on("--#{check}-check", "Enable the #{check} check.") do
+            PuppetLint.configuration.send("enable_#{check}")
+          end
+        end
 
-        opts.on("--#{check}-check", "Enable the #{check} check.") do
-          PuppetLint.configuration.send("enable_#{check}")
+        next unless PuppetLint.configuration.send("#{check}_supports_config?")
+
+        opts.on("--#{check}-config FILE", "Additional configuration for the #{check} check.") do |value|
+          if PuppetLint.configuration.check_config.nil?
+            PuppetLint.configuration.check_config = Hash.new()
+          end
+          PuppetLint.configuration.check_config[check] = value
         end
       end
     end

--- a/lib/puppet-lint/plugins/check_documentation/advanced_doc_comments.rb
+++ b/lib/puppet-lint/plugins/check_documentation/advanced_doc_comments.rb
@@ -1,0 +1,74 @@
+# Public: Check the class or defined type comments for a multitude of conventions and record a warning
+# if the convention isn't agreed upon
+PuppetLint.new_check(:advanced_doc_comments) do
+  def check
+    PuppetLint.configuration.add_option('check_config')
+
+    return if PuppetLint.configuration.check_config.nil?
+    return unless PuppetLint.configuration.check_config.key?(:advanced_doc_comments)
+    ruleset = JSON.load_file(PuppetLint.configuration.check_config[:advanced_doc_comments])
+
+    (class_indexes + defined_type_indexes).each do |item_idx|
+      comment_token = find_comment_token(item_idx[:tokens].first)
+      next if comment_token.nil?
+
+      first_token = item_idx[:tokens].first
+
+      comment = get_comment(comment_token)
+      code = get_code(first_token)
+      type = if first_token.type == :CLASS
+               'class'
+             else
+               'defined type'
+             end
+
+      ruleset.each do |rule_name, rule|
+        condition = Regexp.new(
+          rule.key?('condition') ? rule['condition'] : '.+', Regexp::MULTILINE | Regexp::IGNORECASE
+        )
+        comment_condition = Regexp.new(
+          rule.key?('comment-condition') ? rule['comment-condition'] : '.+', Regexp::MULTILINE | Regexp::IGNORECASE
+        )
+        check = Regexp.new(rule['check'], Regexp::MULTILINE | Regexp::IGNORECASE)
+
+        next unless condition.match?(code)
+        next unless comment_condition.match?(code)
+        next if check.match?(comment)
+
+        notify(
+          :warning,
+          :message => "Advanced doc comments rule #{rule_name} failed on #{type}",
+          :line => first_token.line,
+          :column => first_token.column
+        )
+      end
+    end
+  end
+
+  # Get the full comment text
+  def get_comment(start_token)
+    text = start_token.value
+    next_token = start_token.next_token
+    while (COMMENT_TOKENS + WHITESPACE_TOKENS).include?(next_token.type)
+      text += next_token.value
+      next_token = next_token.next_token
+    end
+    text
+  end
+
+  # Get the full class or type code. Expects to start with the CLASS or TYPE token
+  def get_code(start_token)
+    code = start_token.value
+    brace_depth = 0
+    next_token = start_token.next_token
+    until next_token.nil?
+      code += next_token.value
+      brace_depth += 1 if next_token.type == :LBRACE
+      brace_depth -= 1 if next_token.type == :RBRACE
+      break if brace_depth.zero? && next_token.type == :RBRACE
+      next_token = next_token.next_token
+    end
+    code
+  end
+end
+PuppetLint.configuration.send('advanced_doc_comments_supports_config')

--- a/lib/puppet-lint/plugins/check_documentation/documentation.rb
+++ b/lib/puppet-lint/plugins/check_documentation/documentation.rb
@@ -28,19 +28,4 @@ PuppetLint.new_check(:documentation) do
       )
     end
   end
-
-  def find_comment_token(start_token)
-    newlines = 0
-
-    prev_token = start_token.prev_token
-    while !prev_token.nil? && WHITESPACE_TOKENS.include?(prev_token.type)
-      newlines += 1 if prev_token.type == :NEWLINE
-      break if newlines > 1
-      prev_token = prev_token.prev_token
-    end
-
-    return if prev_token.nil?
-
-    prev_token if COMMENT_TOKENS.include?(prev_token.type)
-  end
 end

--- a/spec/puppet-lint/plugins/check_documentation/advanced_doc_comments_rules.json
+++ b/spec/puppet-lint/plugins/check_documentation/advanced_doc_comments_rules.json
@@ -1,0 +1,13 @@
+{
+    "summary-exists": {
+        "check": "@summary"
+    },
+    "summary-is-indented": {
+        "comment-condition": "@summary",
+        "check": "@summary\\n  .+"
+    },
+    "params-are-documented": {
+        "condition": "(class|define) [^ ]+ \\([^\\)]+\\)",
+        "check": "@param"
+    }
+}

--- a/spec/puppet-lint/plugins/check_documentation/advanced_doc_comments_spec.rb
+++ b/spec/puppet-lint/plugins/check_documentation/advanced_doc_comments_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe 'advanced_doc_comments' do
+  describe 'Missing summary' do
+    before do
+      PuppetLint.configuration.check_config = Hash[
+        :advanced_doc_comments => 'spec/puppet-lint/plugins/check_documentation/advanced_doc_comments_rules.json'
+      ]
+    end
+
+    after do
+      PuppetLint.configuration.check_config = Hash[]
+    end
+
+    let(:code) do
+      <<-END
+        # foo
+        class test {}
+      END
+    end
+
+    it 'should only detect a single problem' do
+      expect(problems).to have(1).problem
+    end
+
+    it 'should create a warning' do
+      expect(problems)
+        .to contain_warning('Advanced doc comments rule summary-exists failed on class')
+        .on_line(2)
+        .in_column(9)
+    end
+  end
+
+  describe 'Missing parameter documentation' do
+    before do
+      PuppetLint.configuration.check_config = Hash[
+        :advanced_doc_comments => 'spec/puppet-lint/plugins/check_documentation/advanced_doc_comments_rules.json'
+      ]
+    end
+
+    after do
+      PuppetLint.configuration.check_config = Hash[]
+    end
+
+    let(:code) do
+      <<-END
+        # @summary
+        #   foo
+        class test ($param) {}
+      END
+    end
+
+    it 'should only detect a single problem' do
+      expect(problems).to have(1).problem
+    end
+
+    it 'should create a warning' do
+      expect(problems)
+        .to contain_warning('Advanced doc comments rule params-are-documented failed on class')
+        .on_line(3)
+        .in_column(9)
+    end
+  end
+
+  describe 'Missing configuration' do
+    let(:code) do
+      <<-END
+        # @summary
+        #   foo
+        class test ($param) {}
+      END
+    end
+
+    it 'should skip the check' do
+      expect(problems).to have(0).problem
+    end
+  end
+end


### PR DESCRIPTION
We needed a linter to lint Puppet doc comments against our internal code guidelines and I found Puppetlint to have the best basic feature for that.

I hope, this change is in Puppetlints scope and you find it useful.