### PR TITLE
(GH-CAT-98) - Update CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @puppetlabs/devx
+* @puppetlabs/modules


### PR DESCRIPTION
Prior to this commit the CODEOWNERS file for this repository referenced
a legacy team.

Since the efforts of this team have been merged in to CaT (modules) this
commit changes the associated group to https://github.com/orgs/puppetlabs/teams/modules.