### PR TITLE
(GH-47) Expose additional indexes

### DIFF
--- a/lib/puppet-lint/checkplugin.rb
+++ b/lib/puppet-lint/checkplugin.rb
@@ -105,6 +105,38 @@ class PuppetLint::CheckPlugin
     PuppetLint::Data.node_indexes
   end
 
+  # Public: Provides positional information for any array definitions in the
+  # tokens array to the check plugins.
+  #
+  # Returns an array of hashes containing the position information.
+  def array_indexes
+    PuppetLint::Data.array_indexes
+  end
+
+  # Public: Provides positional information for any hash definitions in the
+  # tokens array to the check plugins.
+  #
+  # Returns an array of hashes containing the position information.
+  def hash_indexes
+    PuppetLint::Data.hash_indexes
+  end
+
+  # Public: Provides positional information for any default definitions in the
+  # tokens array to the check plugins.
+  #
+  # Returns an Array of Hashes containing the position information.
+  def defaults_indexes
+    PuppetLint::Data.defaults_indexes
+  end
+
+  # Public: Provides positional information for any function definition in the
+  # tokens array to the check plugins.
+  #
+  # Returns an Array of Hashes containing the position information.
+  def function_indexes
+    PuppetLint::Data.function_indexes
+  end
+
   # Public: Provides the expanded path of the file being analysed to check
   # plugins.
   #


### PR DESCRIPTION
Prior to this commit puppet-lint did not expose the following methods from `PuppetLint::Data`:

* `array_indexes`
* `hash_indexes`
* `defaults_indexes`
* `function_indexes`

This commit adds public methods to `PuppetLint::CheckPlugin` so that the methods above are accessible from puppet-lint plugins.

Fixes #47 