### PR TITLE
(MAINT) Update CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: "ci"
 on:
   push:
     branches:
-      - master
+      - "main"
   pull_request:
     branches:
-      - master
+      - "main"
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:


### PR DESCRIPTION
Prior to this commit the triggers for the ci workflow were set to `master`. This modules default branch has now moved to `main` meaning that the triggers are invalid.

This commit updates the triggers to `main` so that workflows are correctly triggered on pushes and pull requests.