### PR TITLE
(MAINT) Fix spacing issue

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace/140chars.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/140chars.rb
@@ -7,7 +7,7 @@
 PuppetLint.new_check(:'140chars') do
   def check
     manifest_lines.each_with_index do |line, idx|
-      result = PuppetLint::LineLengthCheck.check(idx+1, line, 140)
+      result = PuppetLint::LineLengthCheck.check(idx + 1, line, 140)
 
       next if result.nil?
       notify(*result)

--- a/lib/puppet-lint/plugins/check_whitespace/80chars.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/80chars.rb
@@ -6,7 +6,7 @@
 PuppetLint.new_check(:'80chars') do
   def check
     manifest_lines.each_with_index do |line, idx|
-      result = PuppetLint::LineLengthCheck.check(idx+1, line, 80)
+      result = PuppetLint::LineLengthCheck.check(idx + 1, line, 80)
 
       next if result.nil?
       notify(*result)


### PR DESCRIPTION
Prior to this commit a rubocop was still generating suggestions for the two line length checks. This was because there was missing whitespace around the `+` operand.

This commit adds the space to satisfy rubocop.