### PR TITLE
(GH-42) Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM alpine:3.10
+FROM ruby:2.7-alpine
 
-RUN apk add --no-cache ruby=2.5.7-r0 ruby-json=2.5.7-r0 && \
-    mkdir /puppet-lint /puppet
+RUN mkdir /puppet-lint /puppet
 
 VOLUME /puppet
 WORKDIR /puppet


### PR DESCRIPTION
Prior to this PR the docker build process fails with:

`Error: unable to select packages`

This commit fixes the above by using the official ruby image and pinning the version to 2.7.

While this PR fixes a bug, it does not actually change the code so it has been labeled as `maintenance`.