### PR TITLE
(MAINT) Add rubocop config to gemspec

### DIFF
--- a/puppet-lint.gemspec
+++ b/puppet-lint.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |spec|
   spec.files = Dir[
     'README.md',
     'LICENSE',
+    '.rubocop.yml',
     'lib/**/*',
     'bin/**/*',
-    'spec/**/*',
   ]
   spec.executables = Dir['bin/**/*'].map { |f| File.basename(f) }
   spec.require_paths = ['lib']
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   ]
   spec.license = 'MIT'
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7".freeze)
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.7'.freeze)
 end


### PR DESCRIPTION
This commit adds .rubocop.yml as a required file in the gemspec. This is so that other puppet-lint plugins can inherit a common set of rules.

Ultimately this could make navigating the landscape easier if coding style is simiar.