### PR TITLE
(MAINT) Remove version constraint for rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rake', '~> 10.0'
+  gem 'rake'
   gem 'rspec-its', '~> 1.0'
   gem 'rspec-collection_matchers', '~> 1.0'
 


### PR DESCRIPTION
Prior to this PR the version of rake installed with this project was vulnerable to an OS command injection attach.

The CVE ID for this is: CVE-2020-8130

This PR fixes the above by removing the version constraint and ensuring that the latest version of rake is always pulled.