### PR TITLE
(MAINT) Restore spec files in gems

### DIFF
--- a/puppet-lint.gemspec
+++ b/puppet-lint.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
     '.rubocop.yml',
     'lib/**/*',
     'bin/**/*',
+    'spec/**/*',
   ]
   spec.executables = Dir['bin/**/*'].map { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
This commit corrects a regression caused by the removal of `spec/**/*',` in the gemspec.

As noted by @ekohl in #60, it would break every plugin due to the consumption of the spec helpers from puppet-lint.