### PR TITLE
Fix plugin regressions introduced in 3.0.0

### DIFF
--- a/lib/puppet-lint/plugins.rb
+++ b/lib/puppet-lint/plugins.rb
@@ -10,16 +10,13 @@ class PuppetLint::Plugins
   #
   # Returns nothing.
   def self.load_from_gems
-    plugins_directories = gem_directories.select do |directory|
-      (directory + 'puppet-lint/plugins').to_s if (directory + 'puppet-lint/plugins').directory?
-    end
+    gem_directories.each do |directory|
+      path = directory + 'puppet-lint/plugins'
+      next unless path.directory?
 
-    plugin_files = plugins_directories.each do |directory|
-      Dir["#{directory}/**/*.rb"]
-    end
-
-    plugin_files.each do |file|
-      load(file)
+      Dir["#{path}/**/*.rb"].each do |file|
+        load(file)
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -134,7 +134,7 @@ RSpec.configure do |config|
   config.include(
     RSpec::LintExampleGroup,
     type: :lint,
-    file_path: Regexp.compile(['spec', 'unit', 'puppet-lint', 'plugins'].join('[\\\/]')),
+    file_path: Regexp.new('spec[\\\/](unit[\\\/])?puppet-lint[\\\/]plugins'),
   )
 
   config.expect_with(:rspec) do |c|


### PR DESCRIPTION
This allows plugins to work again. See individual commits for details.

Fixes https://github.com/puppetlabs/puppet-lint/issues/65