### PR TITLE
(MAINT) Bump gem version to 3.0.1

### DIFF
--- a/lib/puppet-lint/version.rb
+++ b/lib/puppet-lint/version.rb
@@ -1,3 +1,3 @@
 class PuppetLint
-  VERSION = '3.0.0'.freeze
+  VERSION = '3.0.1'.freeze
 end


### PR DESCRIPTION
This commit bumps the puppet-lint gem version to 3.0.1.