### PR TITLE
Fix assertion when rspec-json_expectations is missing

### DIFF
--- a/spec/unit/puppet-lint/bin_spec.rb
+++ b/spec/unit/puppet-lint/bin_spec.rb
@@ -378,7 +378,7 @@ describe PuppetLint::Bin do
       if respond_to?(:include_json)
         is_expected.to include_json([[{ 'KIND' => 'WARNING' }]])
       else
-        is_expected.to match(%r{\[\n  \{})
+        is_expected.to match(%r{\[\n  \[\n    \{})
       end
     end
   end
@@ -397,7 +397,7 @@ describe PuppetLint::Bin do
       if respond_to?(:include_json)
         is_expected.to include_json([[{ 'KIND' => 'ERROR' }], [{ 'KIND' => 'WARNING' }]])
       else
-        is_expected.to match(%r{\[\n  \{})
+        is_expected.to match(%r{\[\n  \[\n    \{})
       end
     end
   end


### PR DESCRIPTION
In 21f5743521fe36f4cc04f87ea62b63d9b5a9567e the output was changed and the code path when rspec-json_expectations is present was updated, but not without. While this is an odd code path (since Gemfile does declare it as a dependency), it can be hit if a different dependency mechanism is used (in particular: run the test suite in RPM's %check phase with explicit BuildRequires) and the expectations should be correct.

Fixes: 21f5743521fe36f4cc04f87ea62b63d9b5a9567e