### PR TITLE
Updating doc links to centre on puppet-lint to work on githubpages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,6 @@
 highlighter: rouge
 exclude: ["vendor"]
 markdown: kramdown
-
+baseurl: /puppet-lint
 redcarpet:
   extensions: ["table"]

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,9 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <title>puppet-lint</title>
 
-    <link rel="stylesheet" href="/css/bootstrap.min.css">
-    <link rel="stylesheet" href="/css/simple-sidebar.css">
-    <link rel="stylesheet" href="/css/pygment_trac.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/simple-sidebar.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/pygment_trac.css">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
   </head>
   <body>
@@ -15,33 +15,33 @@
       <div id="sidebar-wrapper">
         <ul class="sidebar-nav">
           <li class="sidebar-brand">
-            <a href="/">puppet-lint</a>
+            <a href="{{ site.baseurl }}/">puppet-lint</a>
           </li>
           <li>
-            <a href="/checks/">Checks</a>
+            <a href="{{ site.baseurl }}/checks/">Checks</a>
           </li>
           <li>
-            <a href="/controlcomments/">Control Comments</a>
+            <a href="{{ site.baseurl }}/controlcomments/">Control Comments</a>
           </li>
           <li>
             <a href="#">Developer</a>
             <ul>
               <li>
-                <a href="/developer/tutorial/">Tutorial</a>
+                <a href="{{ site.baseurl }}/developer/tutorial/">Tutorial</a>
               </li>
               <li>
-                <a href="/developer/api/">API Reference</a>
+                <a href="{{ site.baseurl }}/developer/api/">API Reference</a>
               </li>
               <li>
-                <a href="/developer/tokens/">Token Reference</a>
+                <a href="{{ site.baseurl }}/developer/tokens/">Token Reference</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="/plugins/">Community Plugins</a>
+            <a href="{{ site.baseurl }}/plugins/">Community Plugins</a>
           </li>
           <li>
-            <a href="https://github.com/puppetlabs/puppet-lint/blob/main/CHANGELOG.md">Changelog</a>
+            <a href="https://github.com/puppetlabs/puppet-lint/blob/master/CHANGELOG.md">Changelog</a>
           </li>
           <li>
             <a href="https://github.com/puppetlabs/puppet-lint/issues">Issues</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,10 +41,10 @@
             <a href="/plugins/">Community Plugins</a>
           </li>
           <li>
-            <a href="https://github.com/rodjek/puppet-lint/blob/master/CHANGELOG.md">Changelog</a>
+            <a href="https://github.com/puppetlabs/puppet-lint/blob/master/CHANGELOG.md">Changelog</a>
           </li>
           <li>
-            <a href="https://github.com/rodjek/puppet-lint/issues">Issues</a>
+            <a href="https://github.com/puppetlabs/puppet-lint/issues">Issues</a>
           </li>
         </ul>
       </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,7 +41,7 @@
             <a href="{{ site.baseurl }}/plugins/">Community Plugins</a>
           </li>
           <li>
-            <a href="https://github.com/puppetlabs/puppet-lint/blob/master/CHANGELOG.md">Changelog</a>
+            <a href="https://github.com/puppetlabs/puppet-lint/blob/main/CHANGELOG.md">Changelog</a>
           </li>
           <li>
             <a href="https://github.com/puppetlabs/puppet-lint/issues">Issues</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,7 +41,7 @@
             <a href="/plugins/">Community Plugins</a>
           </li>
           <li>
-            <a href="https://github.com/puppetlabs/puppet-lint/blob/master/CHANGELOG.md">Changelog</a>
+            <a href="https://github.com/puppetlabs/puppet-lint/blob/main/CHANGELOG.md">Changelog</a>
           </li>
           <li>
             <a href="https://github.com/puppetlabs/puppet-lint/issues">Issues</a>

--- a/checks/index.md
+++ b/checks/index.md
@@ -11,63 +11,63 @@ how to resolve it.
 
 ### Spacing, Indentation & Whitespace
 
- * ["two-space soft tabs not used"](/puppet-lint/checks/2sp_soft_tabs/)
- * ["tab character found"](/puppet-lint/checks/hard_tabs/)
- * ["trailing whitespace found"](/puppet-lint/checks/trailing_whitespace/)
- * ["line has more than 80 characters"](/puppet-lint/checks/80chars/)
- * ["line has more than 140 characters"](/puppet-lint/checks/140chars/)
- * ["=> is not properly aligned"](/puppet-lint/checks/arrow_alignment/)
+ * ["two-space soft tabs not used"]({{ site.baseurl }}/checks/2sp_soft_tabs/)
+ * ["tab character found"]({{ site.baseurl }}/checks/hard_tabs/)
+ * ["trailing whitespace found"]({{ site.baseurl }}/checks/trailing_whitespace/)
+ * ["line has more than 80 characters"]({{ site.baseurl }}/checks/80chars/)
+ * ["line has more than 140 characters"]({{ site.baseurl }}/checks/140chars/)
+ * ["=> is not properly aligned"]({{ site.baseurl }}/checks/arrow_alignment/)
 
 ### Comments
 
- * ["// comment found"](/puppet-lint/checks/slash_comments/)
- * ["/\* \*/ comment found"](/puppet-lint/checks/star_comments/)
+ * ["// comment found"]({{ site.baseurl }}/checks/slash_comments/)
+ * ["/\* \*/ comment found"]({{ site.baseurl }}/checks/star_comments/)
 
 ### Quoting
 
- * ["double quoted string containing no variables"](/puppet-lint/checks/double_quoted_strings/)
- * ["variable not enclosed in {}"](/puppet-lint/checks/variables_not_enclosed/)
- * ["string containing only a variable"](/puppet-lint/checks/only_variable_string/)
- * ["single quoted string containing a variable found"](/puppet-lint/checks/single_quote_string_with_variables/)
- * ["quoted boolean value found"](/puppet-lint/checks/quoted_booleans/)
- * ["puppet:// URL without modules/ found"](/puppet-lint/checks/puppet_url_without_modules/)
+ * ["double quoted string containing no variables"]({{ site.baseurl }}/checks/double_quoted_strings/)
+ * ["variable not enclosed in {}"]({{ site.baseurl }}/checks/variables_not_enclosed/)
+ * ["string containing only a variable"]({{ site.baseurl }}/checks/only_variable_string/)
+ * ["single quoted string containing a variable found"]({{ site.baseurl }}/checks/single_quote_string_with_variables/)
+ * ["quoted boolean value found"]({{ site.baseurl }}/checks/quoted_booleans/)
+ * ["puppet:// URL without modules/ found"]({{ site.baseurl }}/checks/puppet_url_without_modules/)
 
 ### Resources
 
- * ["unquoted resource title"](/puppet-lint/checks/unquoted_resource_title/)
- * ["ensure found on line but it's not the first attribute"](/puppet-lint/checks/ensure_first_param/)
- * ["symlink target specified in ensure attr"](/puppet-lint/checks/ensure_not_symlink_target/)
- * ["mode should be represented as a 4 digit octal value or symbolic mode"](/puppet-lint/checks/file_mode/)
- * ["unquoted file mode"](/puppet-lint/checks/unquoted_file_mode/)
- * ["duplicate parameter found in resource"](/puppet-lint/checks/duplicate_params/)
+ * ["unquoted resource title"]({{ site.baseurl }}/checks/unquoted_resource_title/)
+ * ["ensure found on line but it's not the first attribute"]({{ site.baseurl }}/checks/ensure_first_param/)
+ * ["symlink target specified in ensure attr"]({{ site.baseurl }}/checks/ensure_not_symlink_target/)
+ * ["mode should be represented as a 4 digit octal value or symbolic mode"]({{ site.baseurl }}/checks/file_mode/)
+ * ["unquoted file mode"]({{ site.baseurl }}/checks/unquoted_file_mode/)
+ * ["duplicate parameter found in resource"]({{ site.baseurl }}/checks/duplicate_params/)
 
 ### Conditionals
 
- * ["selector inside resource block"](/puppet-lint/checks/selector_inside_resource/)
- * ["case statement without a default case"](/puppet-lint/checks/case_without_default/)
+ * ["selector inside resource block"]({{ site.baseurl }}/checks/selector_inside_resource/)
+ * ["case statement without a default case"]({{ site.baseurl }}/checks/case_without_default/)
 
 ### Classes
 
- * ["foo::bar not in autoload module layout"](/puppet-lint/checks/autoloader_layout/)
- * ["right-to-left (<-) relationship"](/puppet-lint/checks/right_to_left_relationship/)
- * ["class defined inside a class"](/puppet-lint/checks/nested_classes_or_defines/)
- * ["define defined inside a class"](/puppet-lint/checks/nested_classes_or_defines/)
- * ["class inherits across namespaces"](/puppet-lint/checks/inherits_across_namespaces/)
- * ["optional parameter listed before required parameter"](/puppet-lint/checks/parameter_order/)
- * ["class inheriting from params class"](/puppet-lint/checks/class_inherits_from_params_class/)
- * ["foo::bar-baz contains a dash"](/puppet-lint/checks/names_containing_dash/)
- * ["arrow should be on right operand's line"](/puppet-lint/checks/arrow_on_right_operand_line/)
+ * ["foo::bar not in autoload module layout"]({{ site.baseurl }}/checks/autoloader_layout/)
+ * ["right-to-left (<-) relationship"]({{ site.baseurl }}/checks/right_to_left_relationship/)
+ * ["class defined inside a class"]({{ site.baseurl }}/checks/nested_classes_or_defines/)
+ * ["define defined inside a class"]({{ site.baseurl }}/checks/nested_classes_or_defines/)
+ * ["class inherits across namespaces"]({{ site.baseurl }}/checks/inherits_across_namespaces/)
+ * ["optional parameter listed before required parameter"]({{ site.baseurl }}/checks/parameter_order/)
+ * ["class inheriting from params class"]({{ site.baseurl }}/checks/class_inherits_from_params_class/)
+ * ["foo::bar-baz contains a dash"]({{ site.baseurl }}/checks/names_containing_dash/)
+ * ["arrow should be on right operand's line"]({{ site.baseurl }}/checks/arrow_on_right_operand_line/)
 
 ### Variables
 
- * ["variable is lowercase"](/puppet-lint/checks/variable_is_lowercase/)
- * ["variable contains a dash"](/puppet-lint/checks/variable_contains_dash/)
- * ["top-scope variable being used without an explicit namespace"](/puppet-lint/checks/variable_scope/)
+ * ["variable is lowercase"]({{ site.baseurl }}/checks/variable_is_lowercase/)
+ * ["variable contains a dash"]({{ site.baseurl }}/checks/variable_contains_dash/)
+ * ["top-scope variable being used without an explicit namespace"]({{ site.baseurl }}/checks/variable_scope/)
 
 ### Documentation
 
- * ["foo::bar not documented"](/puppet-lint/checks/documentation/)
+ * ["foo::bar not documented"]({{ site.baseurl }}/checks/documentation/)
 
 ### Nodes
 
- * ["unquoted node name found"](/puppet-lint/checks/unquoted_node_name/)
+ * ["unquoted node name found"]({{ site.baseurl }}/checks/unquoted_node_name/)

--- a/checks/index.md
+++ b/checks/index.md
@@ -11,63 +11,63 @@ how to resolve it.
 
 ### Spacing, Indentation & Whitespace
 
- * ["two-space soft tabs not used"](/checks/2sp_soft_tabs/)
- * ["tab character found"](/checks/hard_tabs/)
- * ["trailing whitespace found"](/checks/trailing_whitespace/)
- * ["line has more than 80 characters"](/checks/80chars/)
- * ["line has more than 140 characters"](/checks/140chars/)
- * ["=> is not properly aligned"](/checks/arrow_alignment/)
+ * ["two-space soft tabs not used"](/puppet-lint/checks/2sp_soft_tabs/)
+ * ["tab character found"](/puppet-lint/checks/hard_tabs/)
+ * ["trailing whitespace found"](/puppet-lint/checks/trailing_whitespace/)
+ * ["line has more than 80 characters"](/puppet-lint/checks/80chars/)
+ * ["line has more than 140 characters"](/puppet-lint/checks/140chars/)
+ * ["=> is not properly aligned"](/puppet-lint/checks/arrow_alignment/)
 
 ### Comments
 
- * ["// comment found"](/checks/slash_comments/)
- * ["/\* \*/ comment found"](/checks/star_comments/)
+ * ["// comment found"](/puppet-lint/checks/slash_comments/)
+ * ["/\* \*/ comment found"](/puppet-lint/checks/star_comments/)
 
 ### Quoting
 
- * ["double quoted string containing no variables"](/checks/double_quoted_strings/)
- * ["variable not enclosed in {}"](/checks/variables_not_enclosed/)
- * ["string containing only a variable"](/checks/only_variable_string/)
- * ["single quoted string containing a variable found"](/checks/single_quote_string_with_variables/)
- * ["quoted boolean value found"](/checks/quoted_booleans/)
- * ["puppet:// URL without modules/ found"](/checks/puppet_url_without_modules/)
+ * ["double quoted string containing no variables"](/puppet-lint/checks/double_quoted_strings/)
+ * ["variable not enclosed in {}"](/puppet-lint/checks/variables_not_enclosed/)
+ * ["string containing only a variable"](/puppet-lint/checks/only_variable_string/)
+ * ["single quoted string containing a variable found"](/puppet-lint/checks/single_quote_string_with_variables/)
+ * ["quoted boolean value found"](/puppet-lint/checks/quoted_booleans/)
+ * ["puppet:// URL without modules/ found"](/puppet-lint/checks/puppet_url_without_modules/)
 
 ### Resources
 
- * ["unquoted resource title"](/checks/unquoted_resource_title/)
- * ["ensure found on line but it's not the first attribute"](/checks/ensure_first_param/)
- * ["symlink target specified in ensure attr"](/checks/ensure_not_symlink_target/)
- * ["mode should be represented as a 4 digit octal value or symbolic mode"](/checks/file_mode/)
- * ["unquoted file mode"](/checks/unquoted_file_mode/)
- * ["duplicate parameter found in resource"](/checks/duplicate_params/)
+ * ["unquoted resource title"](/puppet-lint/checks/unquoted_resource_title/)
+ * ["ensure found on line but it's not the first attribute"](/puppet-lint/checks/ensure_first_param/)
+ * ["symlink target specified in ensure attr"](/puppet-lint/checks/ensure_not_symlink_target/)
+ * ["mode should be represented as a 4 digit octal value or symbolic mode"](/puppet-lint/checks/file_mode/)
+ * ["unquoted file mode"](/puppet-lint/checks/unquoted_file_mode/)
+ * ["duplicate parameter found in resource"](/puppet-lint/checks/duplicate_params/)
 
 ### Conditionals
 
- * ["selector inside resource block"](/checks/selector_inside_resource/)
- * ["case statement without a default case"](/checks/case_without_default/)
+ * ["selector inside resource block"](/puppet-lint/checks/selector_inside_resource/)
+ * ["case statement without a default case"](/puppet-lint/checks/case_without_default/)
 
 ### Classes
 
- * ["foo::bar not in autoload module layout"](/checks/autoloader_layout/)
- * ["right-to-left (<-) relationship"](/checks/right_to_left_relationship/)
- * ["class defined inside a class"](/checks/nested_classes_or_defines/)
- * ["define defined inside a class"](/checks/nested_classes_or_defines/)
- * ["class inherits across namespaces"](/checks/inherits_across_namespaces/)
- * ["optional parameter listed before required parameter"](/checks/parameter_order/)
- * ["class inheriting from params class"](/checks/class_inherits_from_params_class/)
- * ["foo::bar-baz contains a dash"](/checks/names_containing_dash/)
- * ["arrow should be on right operand's line"](/checks/arrow_on_right_operand_line/)
+ * ["foo::bar not in autoload module layout"](/puppet-lint/checks/autoloader_layout/)
+ * ["right-to-left (<-) relationship"](/puppet-lint/checks/right_to_left_relationship/)
+ * ["class defined inside a class"](/puppet-lint/checks/nested_classes_or_defines/)
+ * ["define defined inside a class"](/puppet-lint/checks/nested_classes_or_defines/)
+ * ["class inherits across namespaces"](/puppet-lint/checks/inherits_across_namespaces/)
+ * ["optional parameter listed before required parameter"](/puppet-lint/checks/parameter_order/)
+ * ["class inheriting from params class"](/puppet-lint/checks/class_inherits_from_params_class/)
+ * ["foo::bar-baz contains a dash"](/puppet-lint/checks/names_containing_dash/)
+ * ["arrow should be on right operand's line"](/puppet-lint/checks/arrow_on_right_operand_line/)
 
 ### Variables
 
- * ["variable is lowercase"](/checks/variable_is_lowercase/)
- * ["variable contains a dash"](/checks/variable_contains_dash/)
- * ["top-scope variable being used without an explicit namespace"](/checks/variable_scope/)
+ * ["variable is lowercase"](/puppet-lint/checks/variable_is_lowercase/)
+ * ["variable contains a dash"](/puppet-lint/checks/variable_contains_dash/)
+ * ["top-scope variable being used without an explicit namespace"](/puppet-lint/checks/variable_scope/)
 
 ### Documentation
 
- * ["foo::bar not documented"](/checks/documentation/)
+ * ["foo::bar not documented"](/puppet-lint/checks/documentation/)
 
 ### Nodes
 
- * ["unquoted node name found"](/checks/unquoted_node_name/)
+ * ["unquoted node name found"](/puppet-lint/checks/unquoted_node_name/)

--- a/developer/api/index.md
+++ b/developer/api/index.md
@@ -27,7 +27,7 @@ any of the methods listed in the "What you can use" section below to inspect
 the manifest.
 
 For a more complete example of writing a `check` method please
-read the [tutorial](/puppet-lint/developer/tutorial/).
+read the [tutorial]({{ site.baseurl }}/developer/tutorial/).
 
 ### fix
 
@@ -41,7 +41,7 @@ the `tokens` Array.  If you need to back out of the `fix` method for whatever
 reason, raise a `PuppetLint::NoFix` exception to skip over the problem.
 
 For a more complete example of writing a `fix` method please read the
-[tutorial](/puppet-lint/developer/tutorial/).
+[tutorial]({{ site.baseurl }}/developer/tutorial/).
 
 ## What you can use
 
@@ -51,11 +51,11 @@ information in your `check` and `fix` methods.
 ### tokens
 
 Returns the tokenised manifest as an Array of
-[`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/) objects.
+[`PuppetLint::Lexer::Token`]({{ site.baseurl }}/developer/tokens/) objects.
 
 ### title_tokens
 
-Returns an Array of [`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/) objects
+Returns an Array of [`PuppetLint::Lexer::Token`]({{ site.baseurl }}/developer/tokens/) objects
 that represent resource titles.
 
 ### resource_indexes
@@ -69,10 +69,10 @@ within the tokenised manifest.  Each Hash has the following Symbol keys:
    to the last token of the resource
  * **:tokens -** A subset of the `tokens` Array, from the `:start` to `:end`
    positions.
- * **:type -** The [`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/) object for
+ * **:type -** The [`PuppetLint::Lexer::Token`]({{ site.baseurl }}/developer/tokens/) object for
    resource type (e.g. `file`, `exec`, etc).
  * **:param_tokens -** An Array of
-   [`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/) objects for the parameter
+   [`PuppetLint::Lexer::Token`]({{ site.baseurl }}/developer/tokens/) objects for the parameter
    names in the resource declaration.
 
 ### class_indexes
@@ -89,9 +89,9 @@ within the tokenised manifest.  Each Hash has the following Symbol keys:
  * **:param_tokens -** A subset of the `tokens` Array covering the class
    parameters.
  * **:type -** The Symbol `:CLASS`
- * **:name_token -**-The [`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/)
+ * **:name_token -**-The [`PuppetLint::Lexer::Token`]({{ site.baseurl }}/developer/tokens/)
    object for the class name.
- * **:inherited_token -** The [`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/)
+ * **:inherited_token -** The [`PuppetLint::Lexer::Token`]({{ site.baseurl }}/developer/tokens/)
    object for the name of the class that has been inherited (if applicable).
 
 ### defined_type_indexes
@@ -109,7 +109,7 @@ keys:
  * **:param_tokens -** A subset of the `tokens` Array covering the defined type
    parameters.
  * **:type -** The Symbol `:DEFINE`
- * **:name_token -**-The [`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/)
+ * **:name_token -**-The [`PuppetLint::Lexer::Token`]({{ site.baseurl }}/developer/tokens/)
    object for the defined type name.
 
 ### fullpath

--- a/developer/api/index.md
+++ b/developer/api/index.md
@@ -27,7 +27,7 @@ any of the methods listed in the "What you can use" section below to inspect
 the manifest.
 
 For a more complete example of writing a `check` method please
-read the [tutorial](/developer/tutorial/).
+read the [tutorial](/puppet-lint/developer/tutorial/).
 
 ### fix
 
@@ -41,7 +41,7 @@ the `tokens` Array.  If you need to back out of the `fix` method for whatever
 reason, raise a `PuppetLint::NoFix` exception to skip over the problem.
 
 For a more complete example of writing a `fix` method please read the
-[tutorial](/developer/tutorial/).
+[tutorial](/puppet-lint/developer/tutorial/).
 
 ## What you can use
 
@@ -51,11 +51,11 @@ information in your `check` and `fix` methods.
 ### tokens
 
 Returns the tokenised manifest as an Array of
-[`PuppetLint::Lexer::Token`](/developer/tokens/) objects.
+[`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/) objects.
 
 ### title_tokens
 
-Returns an Array of [`PuppetLint::Lexer::Token`](/developer/tokens/) objects
+Returns an Array of [`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/) objects
 that represent resource titles.
 
 ### resource_indexes
@@ -69,10 +69,10 @@ within the tokenised manifest.  Each Hash has the following Symbol keys:
    to the last token of the resource
  * **:tokens -** A subset of the `tokens` Array, from the `:start` to `:end`
    positions.
- * **:type -** The [`PuppetLint::Lexer::Token`](/developer/tokens/) object for
+ * **:type -** The [`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/) object for
    resource type (e.g. `file`, `exec`, etc).
  * **:param_tokens -** An Array of
-   [`PuppetLint::Lexer::Token`](/developer/tokens/) objects for the parameter
+   [`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/) objects for the parameter
    names in the resource declaration.
 
 ### class_indexes
@@ -89,9 +89,9 @@ within the tokenised manifest.  Each Hash has the following Symbol keys:
  * **:param_tokens -** A subset of the `tokens` Array covering the class
    parameters.
  * **:type -** The Symbol `:CLASS`
- * **:name_token -**-The [`PuppetLint::Lexer::Token`](/developer/tokens/)
+ * **:name_token -**-The [`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/)
    object for the class name.
- * **:inherited_token -** The [`PuppetLint::Lexer::Token`](/developer/tokens/)
+ * **:inherited_token -** The [`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/)
    object for the name of the class that has been inherited (if applicable).
 
 ### defined_type_indexes
@@ -109,7 +109,7 @@ keys:
  * **:param_tokens -** A subset of the `tokens` Array covering the defined type
    parameters.
  * **:type -** The Symbol `:DEFINE`
- * **:name_token -**-The [`PuppetLint::Lexer::Token`](/developer/tokens/)
+ * **:name_token -**-The [`PuppetLint::Lexer::Token`](/puppet-lint/developer/tokens/)
    object for the defined type name.
 
 ### fullpath

--- a/developer/tutorial/index.md
+++ b/developer/tutorial/index.md
@@ -610,5 +610,5 @@ At this point, your code should look like [this.](https://github.com/puppetlabs/
 
 ## Further reading
 
-For more information, check out the [API reference](/puppet-lint/developer/api/) and
-[Token reference](/puppet-lint/developer/tokens/).
+For more information, check out the [API reference]({{ site.baseurl }}/developer/api/) and
+[Token reference]({{ site.baseurl }}/developer/tokens/).

--- a/developer/tutorial/index.md
+++ b/developer/tutorial/index.md
@@ -54,7 +54,7 @@ at some options. When you find one you're happy with (the MIT license is highly 
 Gem::Specification.new do |spec|
   spec.name        = 'puppet-lint-trailing_newline-check'
   spec.version     = '1.0.0'
-  spec.homepage    = 'https://github.com/rodjek/puppet-lint-trailing_newline-check'
+  spec.homepage    = 'https://github.com/puppetlabs/puppet-lint-trailing_newline-check'
   spec.license     = 'MIT'
   spec.author      = 'Tim Sharpe'
   spec.email       = 'tim@sharpe.id.au'
@@ -206,7 +206,7 @@ ran bundler (e.g. the value of `--path` if you specified one).
 : This file contains the fully resolved dependency information from bundler and
 is generally not committed when writing libraries.
 
-At this point, your code should look like [this.](https://github.com/rodjek/puppet-lint-tutorial-check/tree/step-1)
+At this point, your code should look like [this.](https://github.com/puppetlabs/puppet-lint-tutorial-check/tree/step-1)
 
 ## Finding the problems in the manifest
 Now that all the setup work is done, you can start actually writing some code.
@@ -380,7 +380,7 @@ Finished in 0.00146 seconds
 3 examples, 3 failures
 {% endhighlight %}
 
-At this point, your code should look like [this.](https://github.com/rodjek/puppet-lint-tutorial-check/tree/step-2)
+At this point, your code should look like [this.](https://github.com/puppetlabs/puppet-lint-tutorial-check/tree/step-2)
 
 ### Write the logic
 
@@ -476,7 +476,7 @@ Finished in 0.00246 seconds
 3 examples, 0 failures
 {% endhighlight %}
 
-At this point, your code should look like [this.](https://github.com/rodjek/puppet-lint-tutorial-check/tree/step-3)
+At this point, your code should look like [this.](https://github.com/puppetlabs/puppet-lint-tutorial-check/tree/step-3)
 
 ## Fixing the problems in the manifest
 
@@ -564,7 +564,7 @@ Finished in 0.00529 seconds (files took 0.08811 seconds to load)
 8 examples, 2 failures
 {% endhighlight %}
 
-At this point, your code should look like [this.](https://github.com/rodjek/puppet-lint-tutorial-check/tree/step-4)
+At this point, your code should look like [this.](https://github.com/puppetlabs/puppet-lint-tutorial-check/tree/step-4)
 
 ### Write the logic
 
@@ -597,7 +597,7 @@ Finished in 0.00391 seconds (files took 0.08846 seconds to load)
 8 examples, 0 failures
 {% endhighlight %}
 
-At this point, your code should look like [this.](https://github.com/rodjek/puppet-lint-tutorial-check/tree/step-5)
+At this point, your code should look like [this.](https://github.com/puppetlabs/puppet-lint-tutorial-check/tree/step-5)
 
 ## Publish it!
 
@@ -605,10 +605,10 @@ At this point, your code should look like [this.](https://github.com/rodjek/pupp
  * Build them gem (`gem build puppet-lint-<your check>-check.gemspec`) and push
    it up to RubyGems (`gem push`).
  * Create a pull request on the [puppet-lint community plugins
-   page](https://github.com/rodjek/puppet-lint/tree/gh-pages/plugins/index.md)
+   page](https://github.com/puppetlabs/puppet-lint/tree/gh-pages/plugins/index.md)
    to list your plugin so others can find it.
 
 ## Further reading
 
-For more information, check out the [API reference](/developer/api/) and
-[Token reference](/developer/tokens/).
+For more information, check out the [API reference](/puppet-lint/developer/api/) and
+[Token reference](/puppet-lint/developer/tokens/).

--- a/developer/tutorial/index.md
+++ b/developer/tutorial/index.md
@@ -54,7 +54,7 @@ at some options. When you find one you're happy with (the MIT license is highly 
 Gem::Specification.new do |spec|
   spec.name        = 'puppet-lint-trailing_newline-check'
   spec.version     = '1.0.0'
-  spec.homepage    = 'https://github.com/puppetlabs/puppet-lint-trailing_newline-check'
+  spec.homepage    = 'https://github.com/rodjek/puppet-lint-trailing_newline-check'
   spec.license     = 'MIT'
   spec.author      = 'Tim Sharpe'
   spec.email       = 'tim@sharpe.id.au'
@@ -206,7 +206,7 @@ ran bundler (e.g. the value of `--path` if you specified one).
 : This file contains the fully resolved dependency information from bundler and
 is generally not committed when writing libraries.
 
-At this point, your code should look like [this.](https://github.com/puppetlabs/puppet-lint-tutorial-check/tree/step-1)
+At this point, your code should look like [this.](https://github.com/rodjek/puppet-lint-tutorial-check/tree/step-1)
 
 ## Finding the problems in the manifest
 Now that all the setup work is done, you can start actually writing some code.
@@ -380,7 +380,7 @@ Finished in 0.00146 seconds
 3 examples, 3 failures
 {% endhighlight %}
 
-At this point, your code should look like [this.](https://github.com/puppetlabs/puppet-lint-tutorial-check/tree/step-2)
+At this point, your code should look like [this.](https://github.com/rodjek/puppet-lint-tutorial-check/tree/step-2)
 
 ### Write the logic
 
@@ -476,7 +476,7 @@ Finished in 0.00246 seconds
 3 examples, 0 failures
 {% endhighlight %}
 
-At this point, your code should look like [this.](https://github.com/puppetlabs/puppet-lint-tutorial-check/tree/step-3)
+At this point, your code should look like [this.](https://github.com/rodjek/puppet-lint-tutorial-check/tree/step-3)
 
 ## Fixing the problems in the manifest
 
@@ -564,7 +564,7 @@ Finished in 0.00529 seconds (files took 0.08811 seconds to load)
 8 examples, 2 failures
 {% endhighlight %}
 
-At this point, your code should look like [this.](https://github.com/puppetlabs/puppet-lint-tutorial-check/tree/step-4)
+At this point, your code should look like [this.](https://github.com/rodjek/puppet-lint-tutorial-check/tree/step-4)
 
 ### Write the logic
 
@@ -597,7 +597,7 @@ Finished in 0.00391 seconds (files took 0.08846 seconds to load)
 8 examples, 0 failures
 {% endhighlight %}
 
-At this point, your code should look like [this.](https://github.com/puppetlabs/puppet-lint-tutorial-check/tree/step-5)
+At this point, your code should look like [this.](https://github.com/rodjek/puppet-lint-tutorial-check/tree/step-5)
 
 ## Publish it!
 

--- a/index.md
+++ b/index.md
@@ -37,5 +37,5 @@ apache/manifests/server.pp - FIXED: variable not enclosed in {} on line 56
 ...
 {% endhighlight %}
 
-Head on over to the [checks page](/puppet-lint/checks/) to see a description of each check
+Head on over to the [checks page]({{ site.baseurl }}/checks/) to see a description of each check
 and get some help on how to clear those errors.

--- a/index.md
+++ b/index.md
@@ -37,5 +37,5 @@ apache/manifests/server.pp - FIXED: variable not enclosed in {} on line 56
 ...
 {% endhighlight %}
 
-Head on over to the [checks page](/checks/) to see a description of each check
+Head on over to the [checks page](/puppet-lint/checks/) to see a description of each check
 and get some help on how to clear those errors.

--- a/plugins/index.md
+++ b/plugins/index.md
@@ -19,7 +19,7 @@ Check the plugin's URL for more information on use of its check(s).
 
 > Checks to ensure that your manifest files end with a trailing newline.
 
-| **URL**     | <https://github.com/rodjek/puppet-lint-trailing_newline-check> |
+| **URL**     | <https://github.com/puppetlabs/puppet-lint-trailing_newline-check> |
 | **Install** | `gem install puppet-lint-trailing_newline-check`               |
 {: .table .table-condensed }
 

--- a/plugins/index.md
+++ b/plugins/index.md
@@ -19,7 +19,7 @@ Check the plugin's URL for more information on use of its check(s).
 
 > Checks to ensure that your manifest files end with a trailing newline.
 
-| **URL**     | <https://github.com/puppetlabs/puppet-lint-trailing_newline-check> |
+| **URL**     | <https://github.com/rodjek/puppet-lint-trailing_newline-check> |
 | **Install** | `gem install puppet-lint-trailing_newline-check`               |
 {: .table .table-condensed }
 


### PR DESCRIPTION
Currently all the links in github pages are broken, I am hoping this update should make the links functional