### PR TITLE
Deal with the first token being "trailing whitespace"

### DIFF
--- a/lib/puppet-lint/plugins/check_whitespace/trailing_whitespace.rb
+++ b/lib/puppet-lint/plugins/check_whitespace/trailing_whitespace.rb
@@ -30,7 +30,7 @@ PuppetLint.new_check(:trailing_whitespace) do
 
     prev_token = problem[:token].prev_token
     next_token = problem[:token].next_token
-    prev_token.next_token = next_token
+    prev_token.next_token = next_token unless prev_token.nil?
     next_token.prev_token = prev_token unless next_token.nil?
     tokens.delete(problem[:token])
   end


### PR DESCRIPTION
If the token is considered "trailing whitespace" and needs to be deleted, it tries to remove the item from the linked list. However, that doesn't work on the first and last entries. There already is a clause for the last item, just not the first item.

Currently a draft since this is missing tests.

Fixes #81