### PR TITLE
(CONT-339) Lower Ruby requirement

### DIFF
--- a/puppet-lint.gemspec
+++ b/puppet-lint.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   ]
   spec.license = 'MIT'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.7'.freeze)
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5'.freeze)
 end


### PR DESCRIPTION
To make puppet-lint more accessible and usable in Puppet 6 environments, this commit lowers the required Ruby version to 2.5.