### PR TITLE
(CONT-666) Skip classref types

### DIFF
--- a/lib/puppet-lint/data.rb
+++ b/lib/puppet-lint/data.rb
@@ -155,6 +155,18 @@ class PuppetLint::Data
       end
     end
 
+    # Internal: Determine if the given token contains a CLASSREF in
+    # the token chain..
+    #
+    # Returns a Boolean.
+    def classref?(token)
+      current_token = token
+      while (current_token = current_token.prev_code_token)
+        return true if current_token.type == :CLASSREF
+        return false if current_token.type == :NAME
+      end
+    end
+
     # Internal: Calculate the positions of all resource declarations within the
     # tokenised manifest. These positions only point to the content of the
     # resource declarations, they do not include resource types or titles.
@@ -170,6 +182,7 @@ class PuppetLint::Data
         result = []
         tokens.select { |t| t.type == :COLON }.each do |colon_token|
           next unless colon_token.next_code_token && colon_token.next_code_token.type != :LBRACE
+          next if classref?(colon_token)
 
           rel_start_idx = tokens[marker..-1].index(colon_token)
           break if rel_start_idx.nil?

--- a/spec/unit/puppet-lint/data_spec.rb
+++ b/spec/unit/puppet-lint/data_spec.rb
@@ -33,6 +33,42 @@ describe PuppetLint::Data do
         }
       end
     end
+
+    context 'when given a defaults declaration' do
+      let(:manifest) { "Service { 'foo': }" }
+
+      it 'returns an empty array' do
+        expect(data.resource_indexes).to eq([])
+      end
+    end
+
+    context 'when given a set of resource declarations' do
+      let(:manifest) { <<-MANIFEST }
+        service {
+          'foo':
+            ensure => running,
+        }
+
+        service {
+          'bar':
+            ensure => running;
+          'foobar':
+            ensure => stopped;
+        }
+
+        service { ['first', 'second']:
+          ensure => running,
+        }
+
+        service { 'third':
+          ensure => running,
+        }
+      MANIFEST
+
+      it 'returns an array of resource indexes' do
+        expect(data.resource_indexes.length).to eq(5)
+      end
+    end
   end
 
   describe '.insert' do


### PR DESCRIPTION
This PR updates the `resource_indexes` method so that it will skip CLASSREF tokens.

For more background on this PR please see [#31](https://github.com/voxpupuli/puppet-lint-trailing_comma-check/issues/31)