### PR TITLE
(CONT-233) - Add version input to gem_release_prep.yml

### DIFF
--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -7,10 +7,14 @@ on:
       description: "The target for the release. This can be a commit sha or a branch."
       required: false
       default: "main"
+    version:
+      description: "Version of gem to be released."
+      required: true
 
 jobs:
   release_prep:
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_release_prep.yml@main"
     with:
       target: "${{ github.event.inputs.target }}"
+      version: "${{ github.event.inputs.version }}"
     secrets: "inherit"


### PR DESCRIPTION
Prior to this PR, the version of the gem would need to be manually updated, pushed and merged into main each time before running release_prep.yml.
This PR introduces a "version" input parameter, that can be specified when running the workflow which eliminates the need for the above.