### PR TITLE
Values from enumerable sets of options should not use quotes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ For a complete list of checks, and how to resolve errors on each check, see the 
 * If a resource declaration includes an `ensure` attribute, it should be the first attribute specified.
 * Symbolic links should be declared by using an ensure value of `link` and explicitly specifying a value for the `target` attribute.
 * File modes should be represented as a 4-digit string enclosed in single quotes or use symbolic file modes.
+* If a value is a value from an enumerable set of options, such as `present` and `absent`, it should not be enclosed in quotes at all.
 
 ### Conditionals
 

--- a/lib/puppet-lint/plugins/check_resources/quoted_literal.rb
+++ b/lib/puppet-lint/plugins/check_resources/quoted_literal.rb
@@ -1,0 +1,232 @@
+# Public: Check tokens of parameters, and verify that when the value is from a
+# specific list of alternatives for the parameter, it is not quoted.
+class OpenSet < Set
+end
+
+BOOLYESNO = Set['true', 'false', 'yes', 'no']
+BOOL = Set['true', 'false']
+SIMPLE_TYPES = Set[:STRING, :SSTRING, :NAME]
+ALL_STRING_TYPES = Set[:STRING, :SSTRING, :REGEX, :DQPRE]
+LITERAL_PARAMETERS_BY_RESOURCE = {
+  'exec' => {
+    'logoutput' => Set['true', 'false', 'on_failure'],
+    'provider' => Set['posix', 'shell', 'windows']
+  },
+  'file' => {
+    'ensure' => OpenSet['present', 'absent', 'file', 'directory', 'link'],
+    'backup' => OpenSet['false'],
+    'checksum' => Set[
+      'sha256',
+      'sha256lite',
+      'md5',
+      'md5lite',
+      'sha1',
+      'sha1lite',
+      'sha512',
+      'sha384',
+      'sha224',
+      'mtime',
+      'ctime',
+    ],
+    'force' => BOOLYESNO,
+    'links' => Set['follow', 'manage'],
+    'provider' => Set['posix', 'windows'],
+    'purge' => BOOLYESNO,
+    'recurse' => Set['false', 'remote', 'true'],
+    'replace' => BOOLYESNO,
+    'selinux_ignore_defaults' => BOOL,
+    'show_diff' => BOOLYESNO,
+    'source_permissions' => Set['use', 'use_when_creating', 'ignore'],
+    'sourceselect' => Set['first', 'all']
+  },
+  'filebucket' => {
+    'path' => OpenSet['false']
+  },
+  'group' => {
+    'ensure' => Set['present', 'absent'],
+    'allowdupe' => BOOLYESNO,
+    'attribute_membership' => Set['inclusive', 'minimum'],
+    'auth_membership' => BOOLYESNO,
+    'forcelocal' => BOOLYESNO,
+    'provider' => Set['aix', 'directoryservice', 'groupadd', 'ldap', 'pw', 'windows_adsi'],
+    'system' => BOOLYESNO
+  },
+  'notify' => {
+    'withpath' => BOOL
+  },
+  'package' => {
+    'provider' => Set[
+      'aix',
+      'appdmg',
+      'apple',
+      'apt',
+      'aptitude',
+      'aptrpm',
+      'blastwave',
+      'dnf',
+      'dnfmodule',
+      'dpkg',
+      'fink',
+      'freebsd',
+      'gem',
+      'hpux',
+      'macports',
+      'nim',
+      'openbsd',
+      'opkg',
+      'pacman',
+      'pip2',
+      'pip3',
+      'pip',
+      'pkg',
+      'pkgdmg',
+      'pkgin',
+      'pkgng',
+      'pkgutil',
+      'portage',
+      'ports',
+      'portupgrade',
+      'puppet_gem',
+      'puppetserver_gem',
+      'rpm',
+      'rug',
+      'sun',
+      'sunfreeware',
+      'tdnf',
+      'up2date',
+      'urpmi',
+      'windows',
+      'yum',
+      'zypper',
+    ],
+    'ensure' => OpenSet['present', 'installed', 'absent', 'purged', 'disabled', 'latest'],
+    'allow_virtual' => BOOLYESNO,
+    'allowcdrom' => BOOL,
+    'configfiles' => Set['keep', 'replace'],
+    'enable_only' => BOOLYESNO,
+    'install_only' => BOOLYESNO,
+    'mark' => Set['hold', 'none'],
+    'reinstall_on_refresh' => BOOL
+  },
+  'resources' => {
+    'purge' => BOOLYESNO,
+    'unless_system_user' => OpenSet['true', 'false']
+  },
+  'schedule' => {
+    'period' => Set['hourly', 'daily', 'weekly', 'monthly', 'never'],
+    'periodmatch' => Set['number', 'distance']
+  },
+  'service' => {
+    'ensure' => Set['stopped', 'false', 'running', 'true'],
+    'enable' => Set['true', 'false', 'manual', 'mask', 'delayed'],
+    'hasrestart' => BOOL,
+    'hasstatus' => BOOL,
+    'provider' => Set[
+      'base',
+      'bsd',
+      'daemontools',
+      'debian',
+      'freebsd',
+      'gentoo',
+      'init',
+      'launchd',
+      'openbsd',
+      'openrc',
+      'openwrt',
+      'rcng',
+      'redhat',
+      'runit',
+      'service',
+      'smf',
+      'src',
+      'systemd',
+      'upstart',
+      'windows',
+    ]
+  },
+  'tidy' => {
+    'backup' => OpenSet['false'],
+    'recurse' => OpenSet['true', 'false', 'inf'],
+    'rmdirs' => BOOLYESNO,
+    'type' => Set['atime', 'mtime', 'ctime']
+  },
+  'user' => {
+    'ensure' => Set['present', 'absent', 'role'],
+    'allowdupe' => BOOLYESNO,
+    'attribute_membership' => Set['inclusive', 'minimum'],
+    'auth_membership' => Set['inclusive', 'minimum'],
+    'expiry' => OpenSet['absent'],
+    'forcelocal' => BOOLYESNO,
+    'key_membership' => Set['inclusive', 'minimum'],
+    'managehome' => BOOLYESNO,
+    'membership' => Set['inclusive', 'minimum'],
+    'profile_membership' => Set['inclusive', 'minimum'],
+    'provider' => Set[
+      'aix',
+      'directoryservice',
+      'hpuxuseradd',
+      'ldap',
+      'openbsd',
+      'pw',
+      'user_role_add',
+      'useradd',
+      'windows_adsi',
+    ],
+    'purge_ssh_keys' => OpenSet['true', 'false'],
+    'role_membership' => Set['inclusive', 'minimum'],
+    'system' => BOOLYESNO
+  }
+}.freeze
+
+PuppetLint.new_check(:quoted_literal) do
+  def check
+    resource_indexes.each do |resource|
+      next unless LITERAL_PARAMETERS_BY_RESOURCE.key?(resource[:type].value)
+
+      literal_parameters = LITERAL_PARAMETERS_BY_RESOURCE[resource[:type].value]
+      resource[:param_tokens].each do |param_token|
+        next unless literal_parameters.key?(param_token.value)
+
+        value_token = param_token.next_code_token.next_code_token
+        parameter_values = literal_parameters[param_token.value]
+        if parameter_values.include?(value_token.value)
+          if ALL_STRING_TYPES.include?(value_token.type)
+            notify(
+              :warning,
+              message: 'quoted literal',
+              line: value_token.line,
+              column: value_token.column,
+              token: value_token,
+            )
+          end
+        elsif parameter_values.is_a?(OpenSet)
+          if value_token.type == :NAME
+            notify(
+              :warning,
+              message: 'non-literal value must be quoted',
+              line: value_token.line,
+              column: value_token.column,
+              token: value_token,
+            )
+          end
+        elsif SIMPLE_TYPES.include?(value_token.type)
+          notify(
+            :error,
+            message: 'invalid value',
+            line: value_token.line,
+            column: value_token.column,
+            token: value_token,
+          )
+        end
+      end
+    end
+  end
+
+  def fix(problem)
+    if problem[:message] == 'quoted literal'
+      problem[:token].type = :NAME if (problem[:token].type == :STRING) || (problem[:token].type == :SSTRING)
+    elsif problem[:message] == 'non-literal value must be quoted'
+      problem[:token].type = :SSTRING
+    end
+  end
+end

--- a/spec/unit/puppet-lint/plugins/check_resources/quoted_literal_spec.rb
+++ b/spec/unit/puppet-lint/plugins/check_resources/quoted_literal_spec.rb
@@ -1,0 +1,252 @@
+require 'spec_helper'
+
+describe 'quoted_literal' do
+  let(:msg) { 'quoted literal' }
+
+  context 'with fix disabled' do
+    context 'exec with logoutput' do
+      context 'bare word true' do
+        let(:code) { "exec { 'foo': logoutput => true }" }
+
+        it 'does not detect any problems' do
+          expect(problems.size).to eq(0)
+        end
+      end
+
+      context 'variable value' do
+        let(:code) { "exec { 'foo': logoutput => $something }" }
+
+        it 'does not detect any problems' do
+          expect(problems.size).to eq(0)
+        end
+      end
+
+      context "string 'true'" do
+        let(:code) { "exec { 'foo': logoutput => 'true' }" }
+
+        it 'only detects a single problem' do
+          expect(problems.size).to eq(1)
+        end
+
+        it 'creates a warning' do
+          expect(problems).to contain_warning(msg).on_line(1).in_column(28)
+        end
+      end
+
+      context "string 'bogus'" do
+        let(:msg) { 'invalid value' }
+        let(:code) { "exec { 'foo': logoutput => 'bogus' }" }
+
+        it 'only detects a single problem' do
+          expect(problems.size).to eq(1)
+        end
+
+        it 'creates an error' do
+          expect(problems).to contain_error(msg).on_line(1).in_column(28)
+        end
+      end
+
+      context 'bare word bogus' do
+        let(:msg) { 'invalid value' }
+        let(:code) { "exec { 'foo': logoutput => bogus }" }
+
+        it 'only detects a single problem' do
+          expect(problems.size).to eq(1)
+        end
+
+        it 'creates an error' do
+          expect(problems).to contain_error(msg).on_line(1).in_column(28)
+        end
+      end
+    end
+
+    context 'file with ensure' do
+      context "string 'present'" do
+        let(:code) { "file { 'foo': ensure => 'present' }" }
+
+        it 'only detects a single problem' do
+          expect(problems.size).to eq(1)
+        end
+
+        it 'creates a warning' do
+          expect(problems).to contain_warning(msg).on_line(1).in_column(25)
+        end
+      end
+
+      context "string 'linked_file'" do
+        let(:code) { "file { 'foo': ensure => 'linked_file' }" }
+
+        it 'does not detect any problems' do
+          expect(problems.size).to eq(0)
+        end
+      end
+
+      context 'variable' do
+        let(:code) { 'file { \'foo\': ensure => $something }' }
+
+        it 'does not detect any problems' do
+          expect(problems.size).to eq(0)
+        end
+      end
+
+      context 'string "linked_$foo_file"' do
+        let(:code) { 'file { \'foo\': ensure => "linked_$foo_file" }' }
+
+        it 'does not detect any problems' do
+          expect(problems.size).to eq(0)
+        end
+      end
+
+      context 'bare word linked_file' do
+        let(:msg) { 'non-literal value must be quoted' }
+        let(:code) { "file { 'foo': ensure => linked_file }" }
+
+        it 'only detects a single problem' do
+          expect(problems.size).to eq(1)
+        end
+
+        it 'creates a warning' do
+          expect(problems).to contain_warning(msg).on_line(1).in_column(25)
+        end
+      end
+    end
+
+    context 'multi body file bad ensure values' do
+      let(:code) do
+        <<-END
+          file {
+            '/tmp/foo1':
+              ensure => 'absent';
+            '/tmp/foo2':
+              ensure => 'present';
+            '/tmp/foo3':
+              ensure => 'link';
+          }
+        END
+      end
+
+      it 'detects 3 problems' do
+        expect(problems.size).to eq(3)
+      end
+
+      it 'creates three warnings' do
+        expect(problems).to contain_warning(sprintf(msg)).on_line(3).in_column(25)
+        expect(problems).to contain_warning(sprintf(msg)).on_line(5).in_column(25)
+        expect(problems).to contain_warning(sprintf(msg)).on_line(7).in_column(25)
+      end
+    end
+  end
+
+  context 'with fix enabled' do
+    before(:each) do
+      PuppetLint.configuration.fix = true
+    end
+
+    after(:each) do
+      PuppetLint.configuration.fix = false
+    end
+
+    context "exec with logoutput string 'true'" do
+      let(:code) { "exec { 'foo': logoutput => 'true' }" }
+
+      it 'only detects a single problem' do
+        expect(problems.size).to eq(1)
+      end
+
+      it 'fixes the manifest' do
+        expect(problems).to contain_fixed(msg).on_line(1).in_column(28)
+      end
+
+      it 'unquotes the logoutput parameter' do
+        expect(manifest).to eq("exec { 'foo': logoutput => true }")
+      end
+    end
+
+    context "exec with logoutput string 'bogus'" do
+      let(:code) { "exec { 'foo': logoutput => 'bogus' }" }
+
+      it 'only detects a single problem' do
+        expect(problems.size).to eq(1)
+      end
+
+      it 'does not change the manigest' do
+        expect(manifest).to eq("exec { 'foo': logoutput => 'bogus' }")
+      end
+    end
+
+    context "string 'present'" do
+      let(:code) { "file { 'foo': ensure => 'present' }" }
+
+      it 'only detects a single problem' do
+        expect(problems.size).to eq(1)
+      end
+
+      it 'fixes the manifest' do
+        expect(problems).to contain_fixed(msg).on_line(1).in_column(25)
+      end
+
+      it 'unquotes the logoutput parameter' do
+        expect(manifest).to eq("file { 'foo': ensure => present }")
+      end
+    end
+
+    context 'bare word linked_file' do
+      let(:msg) { 'non-literal value must be quoted' }
+      let(:code) { "file { 'foo': ensure => linked_file }" }
+
+      it 'only detects a single problem' do
+        expect(problems.size).to eq(1)
+      end
+
+      it 'fixes the manifest' do
+        expect(problems).to contain_fixed(msg).on_line(1).in_column(25)
+      end
+
+      it 'unquotes the logoutput parameter' do
+        expect(manifest).to eq("file { 'foo': ensure => 'linked_file' }")
+      end
+    end
+
+    context 'multi body file bad ensure values' do
+      let(:code) do
+        <<-END
+          file {
+            '/tmp/foo1':
+              ensure => 'absent';
+            '/tmp/foo2':
+              ensure => 'present';
+            '/tmp/foo3':
+              ensure => 'link';
+          }
+        END
+      end
+
+      let(:fixed) do
+        <<-END
+          file {
+            '/tmp/foo1':
+              ensure => absent;
+            '/tmp/foo2':
+              ensure => present;
+            '/tmp/foo3':
+              ensure => link;
+          }
+        END
+      end
+
+      it 'detects 3 problems' do
+        expect(problems.size).to eq(3)
+      end
+
+      it 'fixes 3 problems' do
+        expect(problems).to contain_fixed(msg).on_line(3).in_column(25)
+        expect(problems).to contain_fixed(msg).on_line(5).in_column(25)
+        expect(problems).to contain_fixed(msg).on_line(7).in_column(25)
+      end
+
+      it 'unquotes the ensure values' do
+        expect(manifest).to eq(fixed)
+      end
+    end
+  end
+end


### PR DESCRIPTION
From https://www.puppet.com/docs/puppet/6/style_guide.html#style_guide_module_design-quoting:

> If a string is a value from an enumerable set of options, such as present and absent, it SHOULD NOT be enclosed in quotes at all.

Fixes: rodjek/puppet-lint#412