### PR TITLE
(CAT-1301) Pin changelog generator gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :acceptance do
 end
 
 group :development do
-    gem 'github_changelog_generator', require: false
+    gem 'github_changelog_generator', '~> 1.15.0', require: false
     gem 'faraday-retry', require: false
     gem 'pry', require: false
     gem 'pry-byebug', require: false


### PR DESCRIPTION
Prior to this commit, a bundle install on some systems failed due to Gemfile conflicts arising from the changelog generator gem. This commit pins it to v1.15.0

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
