### PR TITLE
(CAT-1488) - Fix rubocop warnings

### DIFF
--- a/rubocop_baseline.yml
+++ b/rubocop_baseline.yml
@@ -81,3 +81,10 @@ Style/Documentation:
   - spec/**/*
 Style/WordArray:
   EnforcedStyle: brackets
+####################################################
+# Cops below here due for deprecation
+####################################################
+# ``Rspec/FilePath`` is going to be deprecated in the next major release of rubocop >=3.0.0: see <https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FilePath>
+# As the new cops are already present, e.g., Rspec/SpecFilePathPathFormat, then disabling this in preparation
+RSpec/FilePath:
+  Enabled: false


### PR DESCRIPTION
## Summary

This PR fixes CI by excluding the soon-to-be deprecated [Rspec/FilePath](<https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FilePath>).  

## Additional Context

During investigation and after running ``bundle exec rubocop --format github`` 2 simultaneous warnings were observed ``Rspec/FilePath`` (deprecated) and ``Rspec/SpecFilePathFormat``:

```
::error file=spec/unit/puppet_lint/puppet-lint_spec.rb,line=1,col=1::RSpec/SpecFilePathFormat: Spec path should end with `puppet_lint*_spec.rb`. (https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SpecFilePathFormat)
::error file=spec/unit/puppet_lint/puppet-lint_spec.rb,line=5,col=1::RSpec/FilePath: Spec path should end with `puppet_lint*_spec.rb`. (https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FilePath)
➜
```

The warning seem to be expecting a ``puppet_lint`` directory rather than the current ``puppet-lint`` one.  After excluding the deprecated ``Rspec/FilePath`` cop, then the rubocop warnings cleared.  

Since this cop is going to be deprecated in the next major release of rubocop >=3.0.0 according to the documentation, I've:

* added the deprecation at the end of ``rubocop_baseline.yml`` to highlight that it is deprecated; and
* raised an issue to track and remove the exclusion when rubocop is upgraded >= 3.0.  See https://github.com/puppetlabs/puppet-lint/issues/159

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
