### PR TITLE
(CAT-1248) Update Published Name and Owner

### DIFF
--- a/puppet-lint.gemspec
+++ b/puppet-lint.gemspec
@@ -2,14 +2,12 @@ $LOAD_PATH.push(File.expand_path('lib', __dir__))
 require 'puppet-lint/version'
 
 Gem::Specification.new do |spec|
-  spec.name = 'puppet-lint'
+  spec.name = 'puppetlabs-puppet-lint'
   spec.version = PuppetLint::VERSION.dup
   spec.homepage = 'https://github.com/puppetlabs/puppet-lint/'
   spec.summary = 'Ensure your Puppet manifests conform with the Puppetlabs style guide'
   spec.description = <<-EOF
     Checks your Puppet manifests against the Puppetlabs style guide and alerts you to any discrepancies.
-    Note: Support for this gem has been moved under a new namespace and as such any future updates from
-    the Puppet team will be released as `puppetlabs-puppet-lint`.
   EOF
 
   spec.files = Dir[
@@ -29,7 +27,6 @@ Gem::Specification.new do |spec|
     'Community Contributors',
   ]
   spec.email = [
-    'tim@sharpe.id.au',
     'modules-team@puppet.com',
   ]
   spec.license = 'MIT'


### PR DESCRIPTION
Gem is to be re-published under the name `puppetlabs-puppet-lint` in order to fully move it under the ownership of `Puppet`.
Author is not being touched.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
