### PR TITLE
(maint) - Release prep v4.2.2

### DIFF
--- a/lib/puppet-lint/version.rb
+++ b/lib/puppet-lint/version.rb
@@ -1,3 +1,3 @@
 class PuppetLint
-  VERSION = '5.0.0'.freeze
+  VERSION = '4.2.2'.freeze
 end

--- a/puppet-lint.gemspec
+++ b/puppet-lint.gemspec
@@ -2,12 +2,14 @@ $LOAD_PATH.push(File.expand_path('lib', __dir__))
 require 'puppet-lint/version'
 
 Gem::Specification.new do |spec|
-  spec.name = 'puppetlabs-puppet-lint'
+  spec.name = 'puppet-lint'
   spec.version = PuppetLint::VERSION.dup
   spec.homepage = 'https://github.com/puppetlabs/puppet-lint/'
   spec.summary = 'Ensure your Puppet manifests conform with the Puppetlabs style guide'
   spec.description = <<-EOF
     Checks your Puppet manifests against the Puppetlabs style guide and alerts you to any discrepancies.
+    Note: Support for this gem has been moved under the github rubygems registry and as such any future updates from
+    the Puppet team will be released under `https://github.com/orgs/puppetlabs/packages/rubygems/puppet-lint`.
   EOF
 
   spec.files = Dir[
@@ -27,6 +29,7 @@ Gem::Specification.new do |spec|
     'Community Contributors',
   ]
   spec.email = [
+    'tim@sharpe.id.au',
     'modules-team@puppet.com',
   ]
   spec.license = 'MIT'


### PR DESCRIPTION
## Summary
Rolling back release v5.0.0.
Releasing puppet-lint gem with reference to newly published rubygem on GitHub registry.
Have added original owner back as this will be the final release under https://rubygems.org/gems/puppet-lint.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
