### PR TITLE
(GH-189) - invalid fact correction for top scope structured fact

### DIFF
--- a/lib/puppet-lint/plugins/top_scope_facts/top_scope_facts.rb
+++ b/lib/puppet-lint/plugins/top_scope_facts/top_scope_facts.rb
@@ -44,6 +44,14 @@ PuppetLint.new_check(:top_scope_facts) do
   end
 
   def fix(problem)
-    problem[:token].value = "facts['" + problem[:token].value.sub(%r{^::}, '') + "']"
+    problem[:token].value.sub!(%r{^::}, '')
+    # checks if the fact is a top level structured fact e.g. ::my_structured_fact['foo']['bar']
+    if %r{\[.*}.match?(problem[:token].value)
+      fact_name = problem[:token].value.sub(%r{\[.*}, '')
+      nested_facts = problem[:token].value.scan(%r{\[.*}).first
+      problem[:token].value = "facts['" + fact_name + "']" + nested_facts
+    else
+      problem[:token].value = "facts['" + problem[:token].value + "']"
+    end
   end
 end

--- a/spec/unit/puppet-lint/plugins/top_scope_facts/top_scope_facts_spec.rb
+++ b/spec/unit/puppet-lint/plugins/top_scope_facts/top_scope_facts_spec.rb
@@ -102,6 +102,18 @@ describe 'top_scope_facts' do
       end
     end
 
+    context 'top scope structured fact not present on allowlist' do
+      let(:code) { "$::my_structured_fact['foo']['test']" }
+
+      it 'detects a problem' do
+        expect(problems).to contain_fixed('top scope fact instead of facts hash').on_line(1).in_column(1)
+      end
+
+      it 'fixes the problem' do
+        expect(manifest).to eq("$facts['my_structured_fact']['foo']['test']")
+      end
+    end
+
     context 'top scope $::trusted hash' do
       let(:code) { "$::trusted['certname']" }
 


### PR DESCRIPTION
## Summary

Prior to this PR, if you had a top scope structured fact like this in your manifest `$::my_structured_fact['foo']['test']`, lint would return an invalid correction when passed the fix flag.

Now, we have altered the top_scope_facts plugin, to first check if it is a structured fact, and if one is found using regex, apply different logic to fix.

## Additional Context
Unstructured top scope fact:
```
$foo = $::my_structured_fact
```
when fixed:
```
bundle exec puppet-lint ./manifest.pp -f
FIXED: top scope fact instead of facts hash on line 1 (check: top_scope_facts)
```
```
$foo = $facts['my_structured_fact']
```

top scope structured fact (& not on allowlist):
```
$foo = $::my_structured_fact['foo']['test']
```

when fixed:
```
bundle exec puppet-lint ./manifest.pp -f
FIXED: top scope fact instead of facts hash on line 1 (check: top_scope_facts)
```
```
$foo = $facts['my_structured_fact']['foo']['test']
```
## Related Issues (if any)
Fixes #189 

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
