### PR TITLE
Fix RSpec/DescribedClass warning

### DIFF
--- a/spec/unit/puppet-lint/lexer_spec.rb
+++ b/spec/unit/puppet-lint/lexer_spec.rb
@@ -256,7 +256,7 @@ describe PuppetLint::Lexer do
     end
 
     context 'treats a variable named the same as the keyword as a variable' do
-      PuppetLint::Lexer::KEYWORDS.each_key do |keyword|
+      described_class::KEYWORDS.each_key do |keyword|
         context "for '#{keyword}'" do
           let(:segments) do
             [


### PR DESCRIPTION
Prior to this the following error occurred:  ``RSpec/DescribedClass: Use `described_class` instead of `PuppetLint::Lexer`. (https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClass)``

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
