### PR TITLE
Fix function call name token type in function_indexes method

### DIFF
--- a/lib/puppet-lint/data.rb
+++ b/lib/puppet-lint/data.rb
@@ -386,7 +386,7 @@ class PuppetLint::Data
       @function_indexes ||= begin
         functions = []
         tokens.each_with_index do |token, token_idx|
-          next unless token.type == :NAME
+          next unless token.type == :FUNCTION_NAME
           next unless token_idx.zero? ||
                       (token_idx == 1 && tokens[0].type == :WHITESPACE) ||
                       [:NEWLINE, :INDENT].include?(token.prev_token.type) ||


### PR DESCRIPTION
## Summary

Currently, the method `function_indexes` in `lib/puppet-lint/data.rb` doesn't work and only returns empty arrays. This is because, when iterating over the `token` array, tokens are skipped if their type does not equal `:NAME` but tokens that represent function call declarations have the type `:FUNCTION_NAME` and are skipped during iteration.

## Additional Context

Steps to reproduce:
1. Create a basic puppet-lint plugin gem.
2. In a `lib/puppet-lint/plugins/<what ever your plugin name is>.rb` file, add `require 'pry'; binding.pry` as the first line in the plugin's `#check` method definition.
3. Create (or edit) the RSpec test for the plugin ensure that the `:code` block that your plugin test will execute against has a Puppet function call in it (i.e. `notice('This is the func')`)
4. Run RSpec. When the pry session starts, type `function_indexes` and see that it returns an empty array.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.

I didn't see any spec tests specific to this method so I didn't update any tests. Let me know if there are tests I should have updated for this.
