### PR TITLE
(HACKATHON) Check for deprecated functions

### DIFF
--- a/lib/puppet-lint/plugins/check_deprecated_functions/deprecated_functions.rb
+++ b/lib/puppet-lint/plugins/check_deprecated_functions/deprecated_functions.rb
@@ -1,7 +1,7 @@
 # Public: A puppet-lint custom check to detect deprecated functions.
 DEPRECATED_FUNCTIONS_VAR_TYPES = Set[:FUNCTION_NAME]
 
-# These functions have been deprecated in stblib and will impact puppet upgrades
+# These functions have been deprecated in stdlib and will impact puppet upgrades
 # between puppet 7 and puppet 8.
 EASY_FUNCTIONS = [
   'strip', 'rstrip', 'getvar', 'sort', 'upcase', 'round', 'chop', 'chomp',

--- a/lib/puppet-lint/plugins/check_deprecated_functions/deprecated_functions.rb
+++ b/lib/puppet-lint/plugins/check_deprecated_functions/deprecated_functions.rb
@@ -1,0 +1,27 @@
+# Public: A puppet-lint custom check to detect deprecated functions.
+DEPRECATED_FUNCTIONS_VAR_TYPES = Set[:FUNCTION_NAME]
+
+# These facts have a one to one correlation between a legacy fact and a new
+# structured fact.
+EASY_FUNCTIONS = [
+  'strip', 'rstrip', 'getvar', 'sort', 'upcase', 'round', 'chop', 'chomp',
+  'ceiling', 'capitalize', 'cammelcase', 'is_array', 'cod',
+  'min', 'max', 'lstrip', 'hash', 'has_key', 'downcase', 'abs', 'dig',
+  'dig44', 'unique'
+].freeze
+
+PuppetLint.new_check(:deprecated_functions) do
+  def check
+    tokens.select { |x| DEPRECATED_FUNCTIONS_VAR_TYPES.include?(x.type) }.each do |token|
+      if EASY_FUNCTIONS.include?(token.value)
+        notify :warning, {
+          message: "Deprecated Function Found: '#{token.value}'",
+          line: token.line,
+          column: token.column,
+          token: token,
+          fact_name: token.value
+        }
+      end
+    end
+  end
+end

--- a/lib/puppet-lint/plugins/check_deprecated_functions/deprecated_functions.rb
+++ b/lib/puppet-lint/plugins/check_deprecated_functions/deprecated_functions.rb
@@ -13,15 +13,15 @@ EASY_FUNCTIONS = [
 PuppetLint.new_check(:deprecated_functions) do
   def check
     tokens.select { |x| DEPRECATED_FUNCTIONS_VAR_TYPES.include?(x.type) }.each do |token|
-      if EASY_FUNCTIONS.include?(token.value)
-        notify :warning, {
-          message: "Deprecated Function Found: '#{token.value}'",
-          line: token.line,
-          column: token.column,
-          token: token,
-          fact_name: token.value
-        }
-      end
+      next unless EASY_FUNCTIONS.include?(token.value)
+
+      notify :warning, {
+        message: "Deprecated Function Found: '#{token.value}'",
+        line: token.line,
+        column: token.column,
+        token: token,
+        fact_name: token.value
+      }
     end
   end
 end

--- a/lib/puppet-lint/plugins/check_deprecated_functions/deprecated_functions.rb
+++ b/lib/puppet-lint/plugins/check_deprecated_functions/deprecated_functions.rb
@@ -5,7 +5,7 @@ DEPRECATED_FUNCTIONS_VAR_TYPES = Set[:FUNCTION_NAME]
 # between puppet 7 and puppet 8.
 EASY_FUNCTIONS = [
   'strip', 'rstrip', 'getvar', 'sort', 'upcase', 'round', 'chop', 'chomp',
-  'ceiling', 'capitalize', 'cammelcase', 'is_array', 'cod',
+  'ceiling', 'capitalize', 'camelcase', 'is_array', 'cod',
   'min', 'max', 'lstrip', 'hash', 'has_key', 'downcase', 'abs', 'dig',
   'dig44', 'unique'
 ].freeze

--- a/lib/puppet-lint/plugins/check_deprecated_functions/deprecated_functions.rb
+++ b/lib/puppet-lint/plugins/check_deprecated_functions/deprecated_functions.rb
@@ -1,8 +1,8 @@
 # Public: A puppet-lint custom check to detect deprecated functions.
 DEPRECATED_FUNCTIONS_VAR_TYPES = Set[:FUNCTION_NAME]
 
-# These facts have a one to one correlation between a legacy fact and a new
-# structured fact.
+# These functions have been deprecated in stblib and will impact puppet upgrades
+# between puppet 7 and puppet 8.
 EASY_FUNCTIONS = [
   'strip', 'rstrip', 'getvar', 'sort', 'upcase', 'round', 'chop', 'chomp',
   'ceiling', 'capitalize', 'cammelcase', 'is_array', 'cod',

--- a/spec/unit/puppet-lint/plugins/check_deprecated_functions/deprecated_functions_spec.rb
+++ b/spec/unit/puppet-lint/plugins/check_deprecated_functions/deprecated_functions_spec.rb
@@ -3,32 +3,32 @@ require 'spec_helper'
 describe 'deprecated_functions' do
   context 'standard' do
     context 'code containing one deprecated function' do
-      let(:code) { "strip()" }
+      let(:code) { 'strip()' }
 
-      it 'should create a warning' do
+      it 'creates a warning' do
         expect(problems.size).to eq(1)
       end
     end
 
     context 'code containing two deprecated functions' do
-      let(:code) { "strip() rstrip()" }
+      let(:code) { 'strip() rstrip()' }
 
-      it 'should create a warning' do
+      it 'creates a warning' do
         expect(problems.size).to eq(2)
       end
     end
 
     context 'code containing one deprecated underscore function' do
-      let(:code) { "is_array()" }
+      let(:code) { 'is_array()' }
 
-      it 'should create a warning' do
+      it 'creates a warning' do
         expect(problems.size).to eq(1)
       end
     end
 
     context 'code with no deprecated functions' do
       let(:code) { 'port()' }
-  
+
       it 'does not detect any problems' do
         expect(problems).to be_empty
       end

--- a/spec/unit/puppet-lint/plugins/check_deprecated_functions/deprecated_functions_spec.rb
+++ b/spec/unit/puppet-lint/plugins/check_deprecated_functions/deprecated_functions_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'deprecated_functions' do
+  context 'standard' do
+    context 'code containing one deprecated function' do
+      let(:code) { "strip()" }
+
+      it 'should create a warning' do
+        expect(problems.size).to eq(1)
+      end
+    end
+
+    context 'code containing two deprecated functions' do
+      let(:code) { "strip() rstrip()" }
+
+      it 'should create a warning' do
+        expect(problems.size).to eq(2)
+      end
+    end
+
+    context 'code containing one deprecated underscore function' do
+      let(:code) { "is_array()" }
+
+      it 'should create a warning' do
+        expect(problems.size).to eq(1)
+      end
+    end
+
+    context 'code with no deprecated functions' do
+      let(:code) { 'port()' }
+  
+      it 'does not detect any problems' do
+        expect(problems).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Check to see if any deprecated Puppet functions are present within the code. These functions where removed as of Puppet 8 and puppetlabs-stdlib v9.0.0

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
