### PR TITLE
Add Error type to the lexer tokens (and sort them)

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -123,7 +123,7 @@ class PuppetLint::Lexer
     [:WHITESPACE, %r{\A(#{WHITESPACE_RE}+)}],
     # FIXME: Future breaking change, the following :TYPE tokens conflict with
     #        the :TYPE keyword token.
-    [:TYPE, %r{\A(Integer|Float|Boolean|Regexp|String|Array|Hash|Resource|Class|Collection|Scalar|Numeric|CatalogEntry|Data|Tuple|Struct|Optional|NotUndef|Variant|Enum|Pattern|Any|Callable|Type|Runtime|Undef|Default|Sensitive|Error)\b}], # rubocop:disable Layout/LineLength
+    [:TYPE, %r{\A(Any|Array|Boolean|Callable|CatalogEntry|Class|Collection|Data|Default|Enum|Error|Float|Hash|Integer|NotUndef|Numeric|Optional|Pattern|Regexp|Resource|Runtime|Scalar|Sensitive|String|Struct|Tuple|Type|Undef|Variant)\b}], # rubocop:disable Layout/LineLength
     [:CLASSREF, %r{\A(((::){0,1}[A-Z][-\w]*)+)}],
     [:NUMBER, %r{\A\b((?:0[xX][0-9A-Fa-f]+|0?\d+(?:\.\d+)?(?:[eE]-?\d+)?))\b}],
     [:FUNCTION_NAME, %r{#{NAME_RE}(?=\()}],

--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -123,7 +123,7 @@ class PuppetLint::Lexer
     [:WHITESPACE, %r{\A(#{WHITESPACE_RE}+)}],
     # FIXME: Future breaking change, the following :TYPE tokens conflict with
     #        the :TYPE keyword token.
-    [:TYPE, %r{\A(Integer|Float|Boolean|Regexp|String|Array|Hash|Resource|Class|Collection|Scalar|Numeric|CatalogEntry|Data|Tuple|Struct|Optional|NotUndef|Variant|Enum|Pattern|Any|Callable|Type|Runtime|Undef|Default|Sensitive)\b}], # rubocop:disable Layout/LineLength
+    [:TYPE, %r{\A(Integer|Float|Boolean|Regexp|String|Array|Hash|Resource|Class|Collection|Scalar|Numeric|CatalogEntry|Data|Tuple|Struct|Optional|NotUndef|Variant|Enum|Pattern|Any|Callable|Type|Runtime|Undef|Default|Sensitive|Error)\b}], # rubocop:disable Layout/LineLength
     [:CLASSREF, %r{\A(((::){0,1}[A-Z][-\w]*)+)}],
     [:NUMBER, %r{\A\b((?:0[xX][0-9A-Fa-f]+|0?\d+(?:\.\d+)?(?:[eE]-?\d+)?))\b}],
     [:FUNCTION_NAME, %r{#{NAME_RE}(?=\()}],

--- a/spec/unit/puppet-lint/lexer_spec.rb
+++ b/spec/unit/puppet-lint/lexer_spec.rb
@@ -1390,6 +1390,12 @@ END
         expect(token.value).to eq('Sensitive')
       end
     end
+
+    it 'matches Error type' do
+      token = lexer.tokenise('Error').first
+      expect(token.type).to eq(:TYPE)
+      expect(token.value).to eq('Error')
+    end
   end
 
   context ':HEREDOC without interpolation' do


### PR DESCRIPTION
## Summary
Error type wasn't known to the lexer. That makes puppet-lint to fire `unquoted_string_in_{selector|case}` on this type check.

## Additional Context
Consider this code:
```puppet
$x ? {
  Error => false,
  default => true,
}
```

Puppet-lint will raise a warning on the line containing the Error.

## Related Issues (if any)

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.