### PR TITLE
add --top-scope-variables cli argument, fix #228

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -60,10 +60,10 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 33
 
-# Offense count: 80
+# Offense count: 81
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
-  Max: 108
+  Max: 111
 
 # Offense count: 26
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -128,6 +128,10 @@ class PuppetLint::OptParser
         PuppetLint.configuration.ignore_paths = paths.split(',')
       end
 
+      opts.on('--top-scope-variables VARS', 'A comma separated list of allowed top scope variables') do |vars|
+        PuppetLint.configuration.top_scope_variables = vars.split(',')
+      end
+
       PuppetLint.configuration.checks.each do |check|
         opts.on("--no-#{check}-check", "Skip the #{check} check.") do
           PuppetLint.configuration.send(:"disable_#{check}")

--- a/spec/fixtures/test/manifests/top_scope_variables.pp
+++ b/spec/fixtures/test/manifests/top_scope_variables.pp
@@ -1,0 +1,4 @@
+# dummy resource to test --top-scope-variables
+define test::top_scope_variables() {
+  notice($::role)
+}

--- a/spec/unit/puppet-lint/bin_spec.rb
+++ b/spec/unit/puppet-lint/bin_spec.rb
@@ -121,6 +121,18 @@ describe PuppetLint::Bin do
     its(:stdout) { is_expected.to eq('') }
   end
 
+  context 'when passed top scope variables option' do
+    let(:args) do
+      [
+        '--top-scope-variables=role',
+        'spec/fixtures/test/manifests/top_scope_variables.pp',
+      ]
+    end
+
+    its(:exitstatus) { is_expected.to eq(0) }
+    its(:stdout) { is_expected.to eq('') }
+  end
+
   context 'when limited to errors only' do
     let(:args) do
       [


### PR DESCRIPTION
## Summary

This adds the ` --top-scope-variables` CLI option that sets `PuppetLint.configuration.top_scope_variables`.

## Related Issues (if any)

#228 

## Checklist
- [X] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
