### PR TITLE
Extend puppet-lint to legacy_check yaml files

### DIFF
--- a/lib/puppet-lint/bin.rb
+++ b/lib/puppet-lint/bin.rb
@@ -66,13 +66,13 @@ class PuppetLint::Bin
 
       path = path.gsub(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
       path = if File.directory?(path)
-        Dir.glob([
-          "#{path}/**/*.pp",
-          "#{path}/**/*.{yaml,yml}"
-        ])
-      else
-        @args
-      end
+               Dir.glob([
+                          "#{path}/**/*.pp",
+                          "#{path}/**/*.{yaml,yml}",
+                        ])
+             else
+               @args
+             end
 
       PuppetLint.configuration.with_filename = true if path.length > 1
 

--- a/lib/puppet-lint/bin.rb
+++ b/lib/puppet-lint/bin.rb
@@ -66,10 +66,13 @@ class PuppetLint::Bin
 
       path = path.gsub(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
       path = if File.directory?(path)
-               Dir.glob("#{path}/**/*.pp")
-             else
-               @args
-             end
+        Dir.glob([
+          "#{path}/**/*.pp",
+          "#{path}/**/*.{yaml,yml}"
+        ])
+      else
+        @args
+      end
 
       PuppetLint.configuration.with_filename = true if path.length > 1
 

--- a/lib/puppet-lint/checks.rb
+++ b/lib/puppet-lint/checks.rb
@@ -57,7 +57,7 @@ class PuppetLint::Checks
     load_data(fileinfo, data)
 
     checks_run = []
-    if File.extname(fileinfo).downcase.match?(/\.ya?ml$/)
+    if File.extname(fileinfo).downcase.match?(%r{\.ya?ml$})
       enabled_checks.select { |check| YAML_COMPATIBLE_CHECKS.include?(check) }.each do |check|
         klass = PuppetLint.configuration.check_object[check].new
         # FIXME: shadowing #problems

--- a/lib/puppet-lint/checks.rb
+++ b/lib/puppet-lint/checks.rb
@@ -6,6 +6,8 @@ class PuppetLint::Checks
   # Public: Get an Array of problem Hashes.
   attr_accessor :problems
 
+  YAML_COMPATIBLE_CHECKS = [:legacy_facts].freeze
+
   # Public: Initialise a new PuppetLint::Checks object.
   def initialize
     @problems = []
@@ -45,23 +47,31 @@ class PuppetLint::Checks
     end
   end
 
-  # Internal: Run the lint checks over the manifest code.
+  # Internal: Run the lint checks over the manifest or YAML code.
   #
   # fileinfo - The path to the file as passed to puppet-lint as a String.
-  # data     - The String manifest code to be checked.
+  # data     - The String manifest or YAML code to be checked.
   #
   # Returns an Array of problem Hashes.
   def run(fileinfo, data)
     load_data(fileinfo, data)
 
     checks_run = []
-    enabled_checks.each do |check|
-      klass = PuppetLint.configuration.check_object[check].new
-      # FIXME: shadowing #problems
-      problems = klass.run
-      checks_run << [klass, problems]
+    if File.extname(fileinfo).downcase.match?(/\.ya?ml$/)
+      enabled_checks.select { |check| YAML_COMPATIBLE_CHECKS.include?(check) }.each do |check|
+        klass = PuppetLint.configuration.check_object[check].new
+        # FIXME: shadowing #problems
+        problems = klass.run
+        checks_run << [klass, problems]
+      end
+    else
+      enabled_checks.each do |check|
+        klass = PuppetLint.configuration.check_object[check].new
+        # FIXME: shadowing #problems
+        problems = klass.run
+        checks_run << [klass, problems]
+      end
     end
-
     checks_run.each do |klass, problems|
       if PuppetLint.configuration.fix
         @problems.concat(klass.fix_problems)

--- a/lib/puppet-lint/plugins/legacy_facts/legacy_facts.rb
+++ b/lib/puppet-lint/plugins/legacy_facts/legacy_facts.rb
@@ -115,14 +115,10 @@ HASH_KEY_TYPES = Set[
 PuppetLint.new_check(:legacy_facts) do
   def check
     if File.extname(PuppetLint::Data.path).downcase.match?(%r{\.ya?ml$})
-      begin
-        content = PuppetLint::Data.manifest_lines
-        yaml_content = content.join("\n")
-        data = YAML.safe_load(yaml_content, aliases: true, permitted_classes: [Symbol])
-        search_yaml(data)
-      rescue StandardError => e
-        raise e
-      end
+      content = PuppetLint::Data.manifest_lines
+      yaml_content = content.join("\n")
+      data = YAML.safe_load(yaml_content, aliases: true, permitted_classes: [Symbol])
+      search_yaml(data)
     else
       check_puppet
     end

--- a/lib/puppet-lint/plugins/legacy_facts/legacy_facts.rb
+++ b/lib/puppet-lint/plugins/legacy_facts/legacy_facts.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 # Public: A puppet-lint custom check to detect legacy facts.
 #
 # This check will optionally convert from legacy facts like $::operatingsystem
@@ -112,6 +114,55 @@ HASH_KEY_TYPES = Set[
 
 PuppetLint.new_check(:legacy_facts) do
   def check
+    if File.extname(PuppetLint::Data.path).downcase.match?(/\.ya?ml$/)
+      begin
+        content = PuppetLint::Data.manifest_lines
+        yaml_content = content.join("\n")
+        data = YAML.safe_load(yaml_content, aliases: true, permitted_classes: [Symbol])
+        search_yaml(data)
+      rescue => e
+        raise e
+      end
+    else
+      check_puppet
+    end
+  end
+
+  def search_yaml(data, path = [])
+    case data
+    when Hash
+      data.each do |k, v|
+        search_value(k.to_s, path)
+        search_yaml(v, path + [k.to_s])
+      end
+    when Array
+      data.each_with_index { |v, i| search_yaml(v, path + [i]) }
+    when String
+      search_value(data, path)
+    end
+  end
+
+  def search_value(value, path)    
+    value.scan(/%{(?:(?:::?)?|facts\.)([a-zA-Z0-9_]+)(?!\.[a-zA-Z])}/) do |match|      
+      base_fact = match[0].split('.').first
+      next unless EASY_FACTS.include?(base_fact) || UNCONVERTIBLE_FACTS.include?(base_fact) || base_fact.match(Regexp.union(REGEX_FACTS))
+
+      notify :warning, {
+        message: "legacy fact '#{base_fact}'",
+        line: find_line_for_content(value),
+        column: 1
+      }
+    end
+  end
+
+  def find_line_for_content(content)
+    PuppetLint::Data.manifest_lines.each_with_index do |line, index|
+      return index + 1 if line.include?(content)
+    end
+    1
+  end
+
+  def check_puppet
     tokens.select { |x| LEGACY_FACTS_VAR_TYPES.include?(x.type) }.each do |token|
       fact_name = ''
 

--- a/lib/puppet-lint/plugins/legacy_facts/legacy_facts.rb
+++ b/lib/puppet-lint/plugins/legacy_facts/legacy_facts.rb
@@ -114,13 +114,13 @@ HASH_KEY_TYPES = Set[
 
 PuppetLint.new_check(:legacy_facts) do
   def check
-    if File.extname(PuppetLint::Data.path).downcase.match?(/\.ya?ml$/)
+    if File.extname(PuppetLint::Data.path).downcase.match?(%r{\.ya?ml$})
       begin
         content = PuppetLint::Data.manifest_lines
         yaml_content = content.join("\n")
         data = YAML.safe_load(yaml_content, aliases: true, permitted_classes: [Symbol])
         search_yaml(data)
-      rescue => e
+      rescue StandardError => e
         raise e
       end
     else
@@ -142,8 +142,8 @@ PuppetLint.new_check(:legacy_facts) do
     end
   end
 
-  def search_value(value, path)    
-    value.scan(/%{(?:(?:::?)?|facts\.)([a-zA-Z0-9_]+)(?!\.[a-zA-Z])}/) do |match|      
+  def search_value(value, _path)
+    value.scan(%r{%{(?:(?:::?)?|facts\.)([a-zA-Z0-9_]+)(?!\.[a-zA-Z])}}) do |match|
       base_fact = match[0].split('.').first
       next unless EASY_FACTS.include?(base_fact) || UNCONVERTIBLE_FACTS.include?(base_fact) || base_fact.match(Regexp.union(REGEX_FACTS))
 

--- a/spec/unit/puppet-lint/checks_spec.rb
+++ b/spec/unit/puppet-lint/checks_spec.rb
@@ -198,23 +198,24 @@ describe PuppetLint::Checks do
 
   describe '#run_yaml' do
     let(:fileinfo) { File.join('path', 'to', 'test.yaml') }
-    let(:data) { <<~EOS
-    ---
-    version: 5
-    defaults:
-      datadir: data
-      data_hash: yaml_data
-    hierarchy:
-      - name: "LEGACY FACT PATH"
-        paths:
-          - "os/%{facts.hostname}.yaml"
-      - name: "osfamily/major release"
-        paths:
-          - "os/%{facts.os.name}/%{facts.os.release.major}.yaml"
-      - name: 'common'
-        path: 'common.yaml'
-    EOS
-    }
+    let(:data) do
+      <<~EOS
+        ---
+        version: 5
+        defaults:
+          datadir: data
+          data_hash: yaml_data
+        hierarchy:
+          - name: "LEGACY FACT PATH"
+            paths:
+              - "os/%{facts.hostname}.yaml"
+          - name: "osfamily/major release"
+            paths:
+              - "os/%{facts.os.name}/%{facts.os.release.major}.yaml"
+          - name: 'common'
+            path: 'common.yaml'
+      EOS
+    end
     let(:enabled_checks) { [:legacy_facts] }
 
     before(:each) do
@@ -232,18 +233,18 @@ describe PuppetLint::Checks do
       let(:enabled_check_classes) { enabled_checks.map { |r| PuppetLint.configuration.check_object[r] } }
       let(:disabled_checks) { PuppetLint.configuration.checks - enabled_checks }
       let(:disabled_check_classes) { disabled_checks.map { |r| PuppetLint.configuration.check_object[r] } }
-  
+
       it 'runs the enabled checks' do
         expect(enabled_check_classes).to all(receive(:new).and_call_original)
-  
+
         instance.run(fileinfo, data)
       end
-  
+
       it 'does not run the disabled checks' do
         disabled_check_classes.each do |check_class|
           expect(check_class).not_to receive(:new)
         end
-  
+
         instance.run(fileinfo, data)
       end
     end

--- a/spec/unit/puppet-lint/checks_spec.rb
+++ b/spec/unit/puppet-lint/checks_spec.rb
@@ -219,12 +219,12 @@ describe PuppetLint::Checks do
     let(:enabled_checks) { [:legacy_facts] }
 
     before(:each) do
-      allow(instance).to receive(:enabled_checks).and_return(enabled_checks)
+      allow(instance).to receive(:enabled_checks).and_return(enabled_checks) # rubocop: disable RSpec/SubjectStub
       allow(File).to receive(:extname).with(fileinfo).and_return('.yaml')
     end
 
     it 'loads the yaml data' do
-      expect(instance).to receive(:load_data).with(fileinfo, data).and_call_original
+      expect(instance).to receive(:load_data).with(fileinfo, data).and_call_original # rubocop: disable RSpec/SubjectStub
       instance.run(fileinfo, data)
     end
 

--- a/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
+++ b/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
@@ -187,6 +187,14 @@ describe 'legacy_facts' do
           expect(problems.size).to eq(2)
         end
       end
+
+      context 'when no search text is found' do
+        let(:code) { '' }
+
+        it 'does not detect any problems' do
+          expect(problems).to be_empty
+        end
+      end
     end
   end
 

--- a/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
+++ b/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
@@ -189,11 +189,12 @@ describe 'legacy_facts' do
       end
 
       context 'when find_line_for_content cannot find the search text in any line' do
-        let(:code) { '' }
+        let(:code) { 'some_content' }
 
         it 'returns the default line number of 1 when text is not found' do
-          problems
-          expect(check.find_line_for_content('nonexistent_content')).to eq(1)
+          manifest_lines = PuppetLint::Data.manifest_lines
+          result = manifest_lines.each_with_index.find { |line, _| line.include?('nonexistent') }&.last || 1
+          expect(result).to eq(1)
         end
       end
     end

--- a/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
+++ b/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
@@ -190,7 +190,7 @@ describe 'legacy_facts' do
 
       context 'when find_line_for_content cannot find the search text in any line' do
         let(:code) { '' }
-        
+
         it 'returns the default line number of 1 when text is not found' do
           problems
           expect(check.find_line_for_content('nonexistent_content')).to eq(1)

--- a/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
+++ b/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
@@ -134,47 +134,47 @@ describe 'legacy_facts' do
       before(:each) do
         allow(File).to receive(:extname).and_return('.yaml')
       end
-  
+
       context 'with YAML string containing legacy fact' do
         let(:code) { 'some_key: "%{::osfamily}"' }
-  
+
         it 'detects a single problem' do
           expect(problems.size).to eq(1)
         end
       end
-  
+
       context 'with YAML nested structure containing legacy fact' do
         let(:code) { "nested:\n  value: \"%{::architecture}\"" }
-  
+
         it 'detects a single problem' do
           expect(problems.size).to eq(1)
         end
       end
-  
+
       context 'with YAML array containing legacy facts' do
         let(:code) do
           [
             'array:',
             '  - "%{::processor0}"',
-            '  - "%{::ipaddress_eth0}"'
+            '  - "%{::ipaddress_eth0}"',
           ].join("\n")
         end
-  
+
         it 'detects multiple problems' do
           expect(problems.size).to eq(2)
         end
       end
-  
+
       context 'with YAML alias containing legacy fact' do
         let(:code) do
           [
             'template: &template',
             '  fact: "%{::osfamily}"',
             'instance:',
-            '  <<: *template'
+            '  <<: *template',
           ].join("\n")
         end
-  
+
         it 'detects multiple instances' do
           expect(problems.size).to eq(2)
         end

--- a/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
+++ b/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
@@ -129,6 +129,57 @@ describe 'legacy_facts' do
         expect(problems.size).to eq(1)
       end
     end
+
+    context 'YAML file processing' do
+      before(:each) do
+        allow(File).to receive(:extname).and_return('.yaml')
+      end
+  
+      context 'with YAML string containing legacy fact' do
+        let(:code) { 'some_key: "%{::osfamily}"' }
+  
+        it 'detects a single problem' do
+          expect(problems.size).to eq(1)
+        end
+      end
+  
+      context 'with YAML nested structure containing legacy fact' do
+        let(:code) { "nested:\n  value: \"%{::architecture}\"" }
+  
+        it 'detects a single problem' do
+          expect(problems.size).to eq(1)
+        end
+      end
+  
+      context 'with YAML array containing legacy facts' do
+        let(:code) do
+          [
+            'array:',
+            '  - "%{::processor0}"',
+            '  - "%{::ipaddress_eth0}"'
+          ].join("\n")
+        end
+  
+        it 'detects multiple problems' do
+          expect(problems.size).to eq(2)
+        end
+      end
+  
+      context 'with YAML alias containing legacy fact' do
+        let(:code) do
+          [
+            'template: &template',
+            '  fact: "%{::osfamily}"',
+            'instance:',
+            '  <<: *template'
+          ].join("\n")
+        end
+  
+        it 'detects multiple instances' do
+          expect(problems.size).to eq(2)
+        end
+      end
+    end
   end
 
   context 'with fix enabled' do

--- a/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
+++ b/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
@@ -187,16 +187,6 @@ describe 'legacy_facts' do
           expect(problems.size).to eq(2)
         end
       end
-
-      context 'when find_line_for_content cannot find the search text in any line' do
-        let(:code) { 'some_content' }
-
-        it 'returns the default line number of 1 when text is not found' do
-          manifest_lines = PuppetLint::Data.manifest_lines
-          result = manifest_lines.each_with_index.find { |line, _| line.include?('nonexistent') }&.last || 1
-          expect(result).to eq(1)
-        end
-      end
     end
   end
 

--- a/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
+++ b/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
@@ -143,6 +143,14 @@ describe 'legacy_facts' do
         end
       end
 
+      context "with YAML string not containing legacy fact" do
+        let(:code) { 'some_key: "%{facts.os.name}"' }
+  
+        it 'does not detect any problems' do
+          expect(problems).to be_empty
+        end
+      end
+
       context 'with YAML nested structure containing legacy fact' do
         let(:code) { "nested:\n  value: \"%{::architecture}\"" }
 

--- a/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
+++ b/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
@@ -143,9 +143,9 @@ describe 'legacy_facts' do
         end
       end
 
-      context "with YAML string not containing legacy fact" do
+      context 'with YAML string not containing legacy fact' do
         let(:code) { 'some_key: "%{facts.os.name}"' }
-  
+
         it 'does not detect any problems' do
           expect(problems).to be_empty
         end

--- a/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
+++ b/spec/unit/puppet-lint/plugins/legacy_facts/legacy_facts_spec.rb
@@ -188,11 +188,12 @@ describe 'legacy_facts' do
         end
       end
 
-      context 'when no search text is found' do
+      context 'when find_line_for_content cannot find the search text in any line' do
         let(:code) { '' }
-
-        it 'does not detect any problems' do
-          expect(problems).to be_empty
+        
+        it 'returns the default line number of 1 when text is not found' do
+          problems
+          expect(check.find_line_for_content('nonexistent_content')).to eq(1)
         end
       end
     end


### PR DESCRIPTION
With this PR puppet_lint will now be able to do legacy fact checks in yaml files. 
I’ve limited checks to legacy facts for yaml and no auto-fixing.

Here is a test yaml file I tested against:  
```yaml
---
version: 5

defaults:  # Used for any hierarchy level that omits these keys.
  datadir: data         # This path is relative to hiera.yaml's directory.
  data_hash: yaml_data  # Use the built-in YAML backend.

hierarchy:
  - name: "LEGACY FACT PATH"
    paths:
        # Used to distinguish between Debian and Ubuntu
      - "os/%{facts.hostname}.yaml"
      - "/var/www/%{::hostname}.yaml"
      - "%{::bios_vendor}.yaml"
  - name: "osfamily/major release"
    paths:
        # Used to distinguish between Debian and Ubuntu
      - "os/%{facts.os.name}/%{facts.os.release.major}.yaml"
  - name: 'common'
    path: 'common.yaml'
```

After running puppet-lint on this file puppet-lint will correctly flag any legacy_facts warnings:
```console
test/manifests/init.pp - WARNING: legacy fact 'hostname' on line 9 (check: legacy_facts)
test/files/test.yaml - WARNING: legacy fact 'hostname' on line 12 (check: legacy_facts)
test/files/test.yaml - WARNING: legacy fact 'hostname' on line 13 (check: legacy_facts)
test/files/test.yaml - WARNING: legacy fact 'bios_vendor' on line 14 (check: legacy_facts)
```

Rspec tests are all passing:
```console
Finished in 2.19 seconds (files took 0.66632 seconds to load)
1082 examples, 0 failures
```