### PR TITLE
Avoid using the manifest lexer on YAML

### DIFF
--- a/lib/puppet-lint/checks.rb
+++ b/lib/puppet-lint/checks.rb
@@ -54,10 +54,11 @@ class PuppetLint::Checks
   #
   # Returns an Array of problem Hashes.
   def run(fileinfo, data)
-    load_data(fileinfo, data)
-
     checks_run = []
     if File.extname(fileinfo).downcase.match?(%r{\.ya?ml$})
+      PuppetLint::Data.path = fileinfo
+      PuppetLint::Data.manifest_lines = data.split("\n", -1)
+
       enabled_checks.select { |check| YAML_COMPATIBLE_CHECKS.include?(check) }.each do |check|
         klass = PuppetLint.configuration.check_object[check].new
         # FIXME: shadowing #problems
@@ -65,6 +66,8 @@ class PuppetLint::Checks
         checks_run << [klass, problems]
       end
     else
+      load_data(fileinfo, data)
+
       enabled_checks.each do |check|
         klass = PuppetLint.configuration.check_object[check].new
         # FIXME: shadowing #problems

--- a/spec/acceptance/puppet_lint_spec.rb
+++ b/spec/acceptance/puppet_lint_spec.rb
@@ -43,4 +43,11 @@ describe 'When executing puppet-lint' do
       expect(result[:stdout]).to have_warnings(2)
     end
   end
+
+  context 'with a YAML file provided' do
+    it 'returns zero errors' do
+      result = puppet_lint([File.join(manifest_root, 'parseable.yaml')])
+      expect(result[:stdout]).to have_errors(0)
+    end
+  end
 end

--- a/spec/fixtures/test/manifests/parseable.yaml
+++ b/spec/fixtures/test/manifests/parseable.yaml
@@ -1,0 +1,3 @@
+---
+heredoc: |
+ contains $

--- a/spec/unit/puppet-lint/checks_spec.rb
+++ b/spec/unit/puppet-lint/checks_spec.rb
@@ -223,11 +223,6 @@ describe PuppetLint::Checks do
       allow(File).to receive(:extname).with(fileinfo).and_return('.yaml')
     end
 
-    it 'loads the yaml data' do
-      expect(instance).to receive(:load_data).with(fileinfo, data).and_call_original # rubocop: disable RSpec/SubjectStub
-      instance.run(fileinfo, data)
-    end
-
     context 'when there are checks enabled' do
       let(:enabled_checks) { [:legacy_facts] }
       let(:enabled_check_classes) { enabled_checks.map { |r| PuppetLint.configuration.check_object[r] } }


### PR DESCRIPTION
## Summary

The new feature of checking YAML files chokes on valid YAML files; this change attempts to mitigate that problem.

## Additional Context

PR #235 added scanning of YAML files to puppet-lint; to my surprise, my CI started failing with a number of syntax errors that hadn't been there before.  Digging into it, it seems to be because the YAML files get fed through `PuppetLint::Lexer`, which doesn't handle some YAML literals correctly (and, being designed for Puppet manifests, I wouldn't expect it to).

Note that a YAML file as included in the change is parsed fine by Psych and yamllint, but puppet-lint chokes on it because it gets fed through the manifest lexer first, which can't cope with some things that are valid YAML.  I have larger examples but this was the smallest reduction I could make that still failed.

Since the one check that operates on YAML files doesn't support fixing and doesn't use tokens, it seems reasonable to bypass the lexer; more sophisticated YAML checks would need to use a separate YAML lexer anyway.

Note that this can't be a unit test because those bypass the lexer processing.  (I only, afterwards, noticed the test for this in `checks_spec` -- I leave it up to you, maintainers, to let me know if you'd rather I put the heredoc case there.)

## Checklist
- [ ] 🟢 Spec tests.
- [X] 🟢 Acceptance tests.
- [X] Manually verified.
