### PR TITLE
Add abstract data types to lexer type tokens list

### DIFF
--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -123,7 +123,38 @@ class PuppetLint::Lexer
     [:WHITESPACE, %r{\A(#{WHITESPACE_RE}+)}],
     # FIXME: Future breaking change, the following :TYPE tokens conflict with
     #        the :TYPE keyword token.
-    [:TYPE, %r{\A(Any|Array|Binary|Boolean|Callable|CatalogEntry|Class|Collection|Data|Default|Enum|Error|Float|Hash|Integer|NotUndef|Numeric|Optional|Pattern|Regexp|Resource|Runtime|Scalar|Sensitive|String|Struct|Tuple|Type|Undef|Variant)\b}], # rubocop:disable Layout/LineLength
+    [:TYPE, %r{\A(
+      Any|
+      Array|
+      Binary|
+      Boolean|
+      Callable|
+      CatalogEntry|
+      Class|
+      Collection|
+      Data|
+      Default|
+      Enum|
+      Error|
+      Float|
+      Hash|
+      Integer|
+      NotUndef|
+      Numeric|
+      Optional|
+      Pattern|
+      Regexp|
+      Resource|
+      Runtime|
+      Scalar|
+      Sensitive|
+      String|
+      Struct|
+      Tuple|
+      Type|
+      Undef|
+      Variant
+    )\b}x],
     [:CLASSREF, %r{\A(((::){0,1}[A-Z][-\w]*)+)}],
     [:NUMBER, %r{\A\b((?:0[xX][0-9A-Fa-f]+|0?\d+(?:\.\d+)?(?:[eE]-?\d+)?))\b}],
     [:FUNCTION_NAME, %r{#{NAME_RE}(?=\()}],

--- a/lib/puppet-lint/lexer.rb
+++ b/lib/puppet-lint/lexer.rb
@@ -139,14 +139,20 @@ class PuppetLint::Lexer
       Float|
       Hash|
       Integer|
+      Iterable|
+      Iterator|
       NotUndef|
       Numeric|
       Optional|
       Pattern|
       Regexp|
       Resource|
+      RichData|
       Runtime|
       Scalar|
+      ScalarData|
+      SemVer|
+      SemVerRange|
       Sensitive|
       String|
       Struct|

--- a/spec/unit/puppet-lint/lexer_spec.rb
+++ b/spec/unit/puppet-lint/lexer_spec.rb
@@ -1392,6 +1392,12 @@ END
 
     it_behaves_like 'a type matcher', 'Error'
     it_behaves_like 'a type matcher', 'Binary'
+    it_behaves_like 'a type matcher', 'Iterable'
+    it_behaves_like 'a type matcher', 'Iterator'
+    it_behaves_like 'a type matcher', 'RichData'
+    it_behaves_like 'a type matcher', 'ScalarData'
+    it_behaves_like 'a type matcher', 'SemVer'
+    it_behaves_like 'a type matcher', 'SemVerRange'
   end
 
   context ':HEREDOC without interpolation' do


### PR DESCRIPTION
- **lexer: use multiple lines for the data type list**
- **lexer: add missing abstract data types**

## Summary
Same as #216 and #224, these abstract data types were missing from the lexer.
