### PR TITLE
feat: introduce --read-paths to threat PATH as a file containing manifest paths

### DIFF
--- a/lib/puppet-lint/bin.rb
+++ b/lib/puppet-lint/bin.rb
@@ -65,14 +65,23 @@ class PuppetLint::Bin
       full_base_path_uri += '/' unless full_base_path_uri.end_with?('/')
 
       path = path.gsub(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
-      path = if File.directory?(path)
-               Dir.glob([
-                          "#{path}/**/*.pp",
-                          "#{path}/**/*.{yaml,yml}",
-                        ])
-             else
-               @args
-             end
+
+      if PuppetLint.configuration.read_paths
+        paths_from_path = []
+        File.readlines(path, chomp: true).each do |line|
+          paths_from_path.append(line)
+        end
+        path = paths_from_path
+      else
+        path = if File.directory?(path)
+                 Dir.glob([
+                            "#{path}/**/*.pp",
+                            "#{path}/**/*.{yaml,yml}",
+                          ])
+               else
+                 @args
+               end
+      end
 
       PuppetLint.configuration.with_filename = true if path.length > 1
 

--- a/lib/puppet-lint/configuration.rb
+++ b/lib/puppet-lint/configuration.rb
@@ -154,5 +154,6 @@ class PuppetLint::Configuration
     self.ignore_paths = ['vendor/**/*.pp']
     self.github_actions = ENV.key?('GITHUB_ACTION')
     self.codeclimate_report_file = ENV.fetch('CODECLIMATE_REPORT_FILE', nil)
+    self.read_paths = false
   end
 end

--- a/lib/puppet-lint/optparser.rb
+++ b/lib/puppet-lint/optparser.rb
@@ -132,6 +132,10 @@ class PuppetLint::OptParser
         PuppetLint.configuration.top_scope_variables = vars.split(',')
       end
 
+      opts.on('--read-paths', 'Threat PATH as a file containing puppet manifest paths.') do
+        PuppetLint.configuration.read_paths = true
+      end
+
       PuppetLint.configuration.checks.each do |check|
         opts.on("--no-#{check}-check", "Skip the #{check} check.") do
           PuppetLint.configuration.send(:"disable_#{check}")

--- a/spec/acceptance/puppet_lint_spec.rb
+++ b/spec/acceptance/puppet_lint_spec.rb
@@ -42,6 +42,12 @@ describe 'When executing puppet-lint' do
       result = puppet_lint([File.join(manifest_root, 'two_warnings.pp')])
       expect(result[:stdout]).to have_warnings(2)
     end
+
+    it 'reads paths from file' do
+      result = puppet_lint(['--read-paths', File.join(manifest_root, 'list')])
+      expect(result[:stdout]).to have_warnings(1)
+      expect(result[:stdout]).to have_errors(1)
+    end
   end
 
   context 'with a YAML file provided' do


### PR DESCRIPTION
## Summary
Introducing --read-paths as a new boolean config option, defaulting to false.
When set to true, we would consider PATH as a file containing puppet manifests to lint, separated by newlines.
This is my first contribution here, so I dont't expect this to be accepted as-is, just let me know what should I improve/change to get this right.

## Additional Context
We are using puppet-lint as part of our cicd pipelines, and we currently have to resort to xargsing each modified puppet manifest in and executing puppet-lint for each file.
With this change we would be able to specify a list of files to lint in a single puppet-lint execution

## Checklist
- [ ] 🟢 Spec tests.
- [ x ] 🟢 Acceptance tests.
- [ x ] Manually verified.
