### PR TITLE
Add missing `require 'pp'`

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ end
 
 require 'puppet-lint'
 require 'rspec/its'
+require 'pp'
 begin
   require 'rspec/json_expectations'
 rescue LoadError, SyntaxError


### PR DESCRIPTION
When using `PP.pp` you still have to `require 'pp'`.

Fixes `uninitialized constant RSpec::LintExampleGroup::HaveProblem::PP`

Also see related discussion in
https://github.com/rubocop/rubocop/issues/11099#issuecomment-1577117258