### PR TITLE
Do not overwrite yaml files with previously read in data

### DIFF
--- a/lib/puppet-lint/checks.rb
+++ b/lib/puppet-lint/checks.rb
@@ -56,6 +56,7 @@ class PuppetLint::Checks
   def run(fileinfo, data)
     checks_run = []
     if File.extname(fileinfo).downcase.match?(%r{\.ya?ml$})
+      PuppetLint::Data.tokens = []
       PuppetLint::Data.path = fileinfo
       PuppetLint::Data.manifest_lines = data.split("\n", -1)
 
@@ -142,6 +143,10 @@ class PuppetLint::Checks
   #
   # Returns the manifest as a String.
   def manifest
-    PuppetLint::Data.tokens.map(&:to_manifest).join
+    if File.extname(PuppetLint::Data.path).downcase.match?(%r{\.ya?ml$})
+      PuppetLint::Data.manifest_lines.join("\n")
+    else
+      PuppetLint::Data.tokens.map(&:to_manifest).join
+    end
   end
 end


### PR DESCRIPTION
## Summary
Do not overwrite yaml files with previously read in data

Fixes issue #254.

Re-initialize the PuppetLine::Data structure when reading in yaml files.

Also, when obtaining the "manifest", return the stored manifest_lines values if the read-in contents are from a yaml file.

## Related Issues (if any)
Issue 254

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.

