### PR TITLE
(CAT-2484) Prevent YAML corruption by making PuppetLint instances file-type aware

### DIFF
--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -235,6 +235,42 @@ class PuppetLint
     report(@problems)
   end
 
+  # Public: Write fixes back to the file if this file type supports fixes.
+  #
+  # Returns nothing.
+  def write_fixes
+    return unless should_write_fixes?
+
+    File.binwrite(@path, @manifest)
+  end
+
+  # Internal: Determine if fixes should be written for this file.
+  #
+  # Returns true if all conditions are met for writing fixes, false otherwise.
+  def should_write_fixes?
+    # Don't write if file type doesn't support fixes
+    return false unless supports_fixes?
+
+    # Don't write if there are syntax errors (can't safely fix)
+    return false if @problems&.any? { |r| r[:check] == :syntax }
+
+    # Don't write if there's no manifest content
+    return false if @manifest.nil? || @manifest.empty?
+
+    true
+  end
+
+  # Public: Determine if this file type supports automatic fixes.
+  #
+  # Returns true if fixes are supported for this file type, false otherwise.
+  def supports_fixes?
+    return false if @path.nil?
+
+    # Only .pp files support fixes currently
+    # YAML files and other types may support fixes in the future
+    File.extname(@path).match?(%r{\.pp$}i)
+  end
+
   # Public: Define a new check.
   #
   # name  - A unique name for the check as a Symbol.

--- a/lib/puppet-lint/bin.rb
+++ b/lib/puppet-lint/bin.rb
@@ -90,9 +90,7 @@ class PuppetLint::Bin
 
         return_val = 1 if l.errors? || (l.warnings? && PuppetLint.configuration.fail_on_warnings)
 
-        next unless PuppetLint.configuration.fix && l.problems.none? { |r| r[:check] == :syntax }
-
-        File.binwrite(f, l.manifest)
+        l.write_fixes if PuppetLint.configuration.fix
       end
 
       if PuppetLint.configuration.sarif

--- a/spec/fixtures/test/manifests/issue_254_overwriting_yaml/class_with_dash.pp
+++ b/spec/fixtures/test/manifests/issue_254_overwriting_yaml/class_with_dash.pp
@@ -1,0 +1,3 @@
+class foo-bar {
+  notify { 'hello': }
+}

--- a/spec/fixtures/test/manifests/issue_254_overwriting_yaml/class_with_dash.yaml
+++ b/spec/fixtures/test/manifests/issue_254_overwriting_yaml/class_with_dash.yaml
@@ -1,0 +1,7 @@
+---
+classes:
+  foo-bar:
+    parameters: []
+    resources:
+      notify:
+        - title: hello

--- a/spec/unit/puppet-lint/bin_spec.rb
+++ b/spec/unit/puppet-lint/bin_spec.rb
@@ -615,6 +615,24 @@ describe PuppetLint::Bin do
     end
   end
 
+  context 'when fixing a directory containing both .pp and .yaml files' do
+    let(:args) { ['--fix', 'spec/fixtures/test/manifests/issue_254_overwriting_yaml'] }
+
+    its(:exitstatus) { is_expected.to eq(1) }
+
+    it 'does not overwrite YAML files' do
+      yaml_file = 'spec/fixtures/test/manifests/issue_254_overwriting_yaml/class_with_dash.yaml'
+      original_yaml = File.read(yaml_file)
+
+      bin # Run the command
+
+      yaml_after = File.read(yaml_file)
+      expect(yaml_after).to eq(original_yaml)
+      expect(yaml_after).to include('classes:')
+      expect(yaml_after).not_to include('class foo-bar {')
+    end
+  end
+
   context 'when overriding config file options with command line options' do
     context 'and config file sets "--only-checks=variable_contains_dash"' do
       around(:context) do |example|

--- a/spec/unit/puppet-lint/bin_spec.rb
+++ b/spec/unit/puppet-lint/bin_spec.rb
@@ -635,7 +635,7 @@ describe PuppetLint::Bin do
 
   context 'when overriding config file options with command line options' do
     context 'and config file sets "--only-checks=variable_contains_dash"' do
-      around(:context) do |example|
+      around(:each) do |example|
         Dir.mktmpdir do |tmpdir|
           Dir.chdir(tmpdir) do
             File.open('.puppet-lint.rc', 'wb') do |f|

--- a/spec/unit/puppet-lint/puppet-lint_spec.rb
+++ b/spec/unit/puppet-lint/puppet-lint_spec.rb
@@ -15,4 +15,53 @@ describe PuppetLint do
     linter.run
     expect(linter.manifest).to eq('')
   end
+
+  describe '#supports_fixes?' do
+    context 'with a .pp file' do
+      it 'returns true' do
+        linter.instance_variable_set(:@path, 'test.pp')
+        expect(linter.supports_fixes?).to be true
+      end
+    end
+
+    context 'with a .yaml file' do
+      it 'returns false' do
+        linter.instance_variable_set(:@path, 'test.yaml')
+        expect(linter.supports_fixes?).to be false
+      end
+    end
+
+    context 'with no path set' do
+      it 'returns false' do
+        expect(linter.supports_fixes?).to be false
+      end
+    end
+  end
+
+  describe '#should_write_fixes?' do
+    before(:each) do
+      linter.instance_variable_set(:@path, 'test.pp')
+      linter.instance_variable_set(:@manifest, 'class test { }')
+    end
+
+    context 'when file supports fixes and has no syntax errors' do
+      it 'returns true' do
+        expect(linter.should_write_fixes?).to be true
+      end
+    end
+
+    context 'when file has syntax errors' do
+      it 'returns false' do
+        linter.instance_variable_set(:@problems, [{ check: :syntax }])
+        expect(linter.should_write_fixes?).to be false
+      end
+    end
+
+    context 'when file type does not support fixes' do
+      it 'returns false' do
+        linter.instance_variable_set(:@path, 'test.yaml')
+        expect(linter.should_write_fixes?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

[GitHub Issue #254](https://github.com/puppetlabs/puppet-lint/issues/254) revealed that puppet-lint's `--fix` flag was incorrectly overwriting YAML files with Puppet manifest content. 

The root cause was in the file processing logic in `bin.rb`, which was applying fix logic to all discovered files (`*.pp`, `*.yaml`, `*.yml`) regardless of file type.  This resulted in YAML configuration files being corrupted with Puppet manifest content, creating potential data loss scenarios in production environments.

## Changes

Since each file has an associated `PuppetLint` instance, then I refactored the file-write logic from `bin.rb` into the `PuppetLint`. This refactor makes each `PuppetLint` file instance aware of its file type and fix eligibility.  Each PuppetLint instance is now responsible for its own behavior based on its file type (and other constraints)

Now `bin.rb` simply calls `fix()` on each `PuppetLint` instance if the user passes the `--fix` flag.  Only if the instance is elegible for a fix will this occur.

## Testing

* manually tested the fix with `bundle exec puppet-lint --fix spec/fixtures/test/manifests/issue_254_overwriting_yaml/`
* added rspec automated tests as well.