### PR TITLE
Do not crash if passed --fix to a yaml file that has problems

### DIFF
--- a/lib/puppet-lint.rb
+++ b/lib/puppet-lint.rb
@@ -225,7 +225,7 @@ class PuppetLint
     @problems = linter.run(@path, @code)
     @problems.each { |problem| @statistics[problem[:kind]] += 1 }
 
-    @manifest = linter.manifest if PuppetLint.configuration.fix
+    @manifest = linter.manifest if PuppetLint.configuration.fix && supports_fixes?
   end
 
   # Public: Print any problems that were found out to stdout.
@@ -269,6 +269,15 @@ class PuppetLint
     # Only .pp files support fixes currently
     # YAML files and other types may support fixes in the future
     File.extname(@path).match?(%r{\.pp$}i)
+  end
+
+  # Public: Determine if the passed in file name supports automatic fixes
+  #
+  # Returns true if fixes are supported for this file type, false otherwise.
+  def self.supports_fixes?(file)
+    # Only .pp files support fixes currently
+    # YAML files and other types may support fixes in the future
+    File.extname(file).match?(%r{\.pp$}i)
   end
 
   # Public: Define a new check.

--- a/lib/puppet-lint/checks.rb
+++ b/lib/puppet-lint/checks.rb
@@ -76,7 +76,7 @@ class PuppetLint::Checks
       end
     end
     checks_run.each do |klass, problems|
-      if PuppetLint.configuration.fix
+      if PuppetLint.configuration.fix && PuppetLint.supports_fixes?(fileinfo)
         @problems.concat(klass.fix_problems)
       else
         @problems.concat(problems)

--- a/spec/fixtures/test/hiera.yaml
+++ b/spec/fixtures/test/hiera.yaml
@@ -1,0 +1,4 @@
+---
+version: 5
+
+sample_key: host.%{::domain}

--- a/spec/unit/puppet-lint/bin_spec.rb
+++ b/spec/unit/puppet-lint/bin_spec.rb
@@ -14,7 +14,13 @@ class CommandRun
     $stderr = err
 
     PuppetLint.configuration.defaults
-    @exitstatus = PuppetLint::Bin.new(args).run
+    begin
+      @exitstatus = PuppetLint::Bin.new(args).run
+    rescue SystemExit => e
+      # When puppet-lint calls exit(1) due to an unhandled exception,
+      # it raises SystemExit. Catch it and use the exit status.
+      @exitstatus = e.status
+    end
     PuppetLint.configuration.defaults
 
     @stdout = out.string.strip
@@ -106,6 +112,20 @@ describe PuppetLint::Bin do
     its(:exitstatus) { is_expected.to eq(1) }
     its(:stdout) { is_expected.to eq('ERROR: Syntax error on line 1 (check: syntax)') }
     its(:stderr) { is_expected.to eq('Try running `puppet parser validate <file>`') }
+  end
+
+  context 'when passed a hiera.yaml file with issues' do
+    let(:args) { 'spec/fixtures/test/hiera.yaml' }
+
+    its(:exitstatus) { is_expected.to eq(0) }
+    its(:stdout) { is_expected.to eq("WARNING: legacy fact 'domain' on line 4 (check: legacy_facts)") }
+  end
+
+  context 'when passed a hiera.yaml file with issues and --fix' do
+    let(:args) { ['--fix', 'spec/fixtures/test/hiera.yaml'] }
+
+    its(:exitstatus) { is_expected.to eq(0) }
+    its(:stdout) { is_expected.to eq("WARNING: legacy fact 'domain' on line 4 (check: legacy_facts)") }
   end
 
   context 'when passed ignore paths option' do


### PR DESCRIPTION
## Summary
Fixes issue #258 

When a YAML file has a legacy fact, passing --fix to puppet-lint produces an unexpected error.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
