### PR TITLE
(CAT-2591) Test against Ruby 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
     name: "spec (ruby ${{ matrix.ruby_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"
@@ -37,6 +38,7 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
     name: "acceptance (ruby ${{ matrix.ruby_version }})"
     needs: "spec"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_acceptance.yml@main"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,7 @@ jobs:
         ruby_version:
           - '3.2'
           - '3.3'
+          - '4.0'
     name: "spec (ruby ${{ matrix.ruby_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"
@@ -27,6 +28,7 @@ jobs:
         ruby_version:
           - '3.2'
           - '3.3'
+          - '4.0'
     name: "acceptance (ruby ${{ matrix.ruby_version }})"
     needs: "spec"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_acceptance.yml@main"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,12 @@ source 'https://rubygems.org'
 
 gemspec
 
+gemsource_puppetcore = if ENV['PUPPET_FORGE_TOKEN']
+  'https://rubygems-puppetcore.puppet.com'
+else
+  ENV['GEM_SOURCE_PUPPETCORE'] || 'https://rubygems.org'
+end
+
 group :test do
   gem 'rake'
   gem 'rspec-its', '~> 1.0'
@@ -18,6 +24,7 @@ group :acceptance do
   gem 'serverspec'
   gem 'puppetlabs_spec_helper'
   gem 'puppet_litmus'
+  gem 'bolt', ENV.fetch('BOLT_GEM_VERSION', nil), source: gemsource_puppetcore
 end
 
 group :development do


### PR DESCRIPTION
With the arrival of Puppetcore 9, we need to ensure that our tools are compatible with Ruby 4. This commit updates our CI workflow to test against Ruby 4.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
